### PR TITLE
fix: Fix audioSetPreferences giving Exception

### DIFF
--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
@@ -217,9 +217,9 @@ internal class PublicationMethodCallHandler() :
             }
 
             "audioSetPreferences" -> {
-                val prefsStr = arguments as String?
+                val prefs = arguments as Map<*, *>?
                 val preferences =
-                    prefsStr?.let { json -> FlutterAudioPreferences.fromJSON(json) }
+                    prefs?.let { FlutterAudioPreferences.fromMap(it) }
                         ?: FlutterAudioPreferences()
 
                 ReadiumReader.audioUpdatePreferences(preferences)

--- a/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
+++ b/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
@@ -193,5 +193,6 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
       methodChannel.invokeMethod('audioEnable', [prefs?.toMap(), fromLocator?.toJson()]);
 
   @override
-  Future<void> audioSetPreferences(AudioPreferences prefs) => methodChannel.invokeMethod('audioSetPreferences', prefs);
+  Future<void> audioSetPreferences(AudioPreferences prefs) =>
+      methodChannel.invokeMethod('audioSetPreferences', prefs.toMap());
 }


### PR DESCRIPTION
# Problem

On Android, trying to call `audioSetPreferences` with any parameter configuration of `AudioPreferences` gives the exception: 
```
Invalid argument: Instance of 'AudioPreferences'
```

## Implemented Solution

Changed how the parameter is passed, mimicking the `audioEnable` function.

## Testing 

### Android
Calling  `audioSetPreferences` and then `previous` or `next` worked. 

### iOS
**When testing on iOS, no exception was thrown, but `previous` and `next` didn't work (didn't skip any audio).** 