### PR TITLE
fix: Correct sync narration media type

### DIFF
--- a/flutter_readium_platform_interface/lib/src/shared/mediatype/mediatype.dart
+++ b/flutter_readium_platform_interface/lib/src/shared/mediatype/mediatype.dart
@@ -259,7 +259,7 @@ class MediaType {
 
   static const MediaType syncMediaNarration = MediaType(
     type: 'application',
-    subtype: 'vnd.synczar+json',
+    subtype: 'vnd.syncnarr+json',
     fileExtension: 'json',
   );
 


### PR DESCRIPTION
## Description 

The sync media narration media type `application/vnd.synczar+json`, used for media overlays, didn't align with the media type used everywhere else in Swift code, Kotlin code and the autogenerated type in _Formats.Next_ (in _epub-to-webpub.xsl_).

## Solution

Changed it to `application/vnd.syncnarr+json`.