### PR TITLE
fix: Compare with full media type

### DIFF
--- a/flutter_readium_platform_interface/lib/src/shared/publication/publication.dart
+++ b/flutter_readium_platform_interface/lib/src/shared/publication/publication.dart
@@ -240,7 +240,7 @@ class Publication with EquatableMixin implements JSONable {
       metadata.conformsTo?.any((c) => c == 'https://readium.org/webpub-manifest/profiles/epub') == true;
 
   bool get containsMediaOverlays =>
-      readingOrder.any((link) => link.alternates.any((alt) => alt.type == MediaType.syncMediaNarration.toString()));
+      readingOrder.any((link) => link.alternates.any((alt) => MediaType.syncMediaNarration.matchesFromName(alt.type)));
 }
 
 class PublicationJsonConverter extends JsonConverter<Publication?, Map<String, dynamic>?> {


### PR DESCRIPTION
## Description

When comparing media types, the comparison compared the alt link's media type with `syncMediaNarration` media type's **name**, which resulted in always returning `false`.

### Solution

Compare with `syncMediaNarration` media type's `toString()` instead, which returns `'$type/$subtype$paramsStr'`, which is what we want; `application/vnd.syncnarr+json`.