### PR TITLE
fix(NOTA-12867): TTSPreferences in dart used voiceIdentifier, kotlin expected a voices map

### DIFF
--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
@@ -132,7 +132,7 @@ data class FlutterTtsPreferences(
                 language = ttsPrefs?.get("language") as? String,
                 pitch = ttsPrefs?.get("pitch") as? Double,
                 speed = ttsPrefs?.get("speed") as? Double,
-                voices = voices,
+                voices = voices.ifEmpty { null },
                 controlPanelInfoType = ControlPanelInfoType.fromString(
                     ttsPrefs?.get("controlPanelInfoType") as? String ?: "standard"
                 )

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
@@ -132,7 +132,7 @@ data class FlutterTtsPreferences(
                 languageOverride = ttsPrefs?.get("languageOverride") as? String,
                 pitch = ttsPrefs?.get("pitch") as? Double,
                 speed = ttsPrefs?.get("speed") as? Double,
-                voices = voices,
+                voices = voices.ifEmpty { null },
                 controlPanelInfoType = ControlPanelInfoType.fromString(
                     ttsPrefs?.get("controlPanelInfoType") as? String ?: "standard"
                 )

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
@@ -14,7 +14,7 @@ import org.readium.r2.shared.util.Language
  */
 @Serializable
 data class FlutterTtsPreferences(
-    val language: String? = null,
+    val languageOverride: String? = null,
     val pitch: Double? = null,
     val speed: Double? = null,
     val voices: Map<String, String>? = null,
@@ -31,7 +31,7 @@ data class FlutterTtsPreferences(
 
         // If no language in preferences, use the first language of the preferred voices.
         val androidLanguage =
-            language?.let { Language(it) } ?: androidVoices?.firstNotNullOfOrNull { it.key }
+            languageOverride?.let { Language(it) } ?: androidVoices?.firstNotNullOfOrNull { it.key }
         return AndroidTtsPreferences(
             language = androidLanguage,
             pitch = pitch,
@@ -42,7 +42,7 @@ data class FlutterTtsPreferences(
 
     fun plus(other: FlutterTtsPreferences): FlutterTtsPreferences =
         FlutterTtsPreferences(
-            language = other.language ?: language,
+            languageOverride = other.languageOverride ?: languageOverride,
             pitch = other.pitch ?: pitch,
             speed = other.speed ?: speed,
             voices = other.voices ?: voices,
@@ -70,7 +70,7 @@ data class FlutterTtsPreferences(
                 }
             }
             return FlutterTtsPreferences(
-                language = jsonObject.optNullableString("language"),
+                languageOverride = jsonObject.optNullableString("language"),
                 pitch = jsonObject.optDouble("pitch").let { if (it.isNaN()) null else it },
                 speed = jsonObject.optDouble("speed").let { if (it.isNaN()) null else it },
                 voices = voicesMap.ifEmpty { null },
@@ -88,7 +88,7 @@ data class FlutterTtsPreferences(
          */
         fun toJSON(preferences: FlutterTtsPreferences): JSONObject {
             val jsonObject = JSONObject()
-            jsonObject.put("language", preferences.language)
+            jsonObject.put("languageOverride", preferences.languageOverride)
             jsonObject.put("pitch", preferences.pitch)
             jsonObject.put("speed", preferences.speed)
             preferences.voices?.let { voices ->
@@ -129,7 +129,7 @@ data class FlutterTtsPreferences(
             }
 
             return FlutterTtsPreferences(
-                language = ttsPrefs?.get("language") as? String,
+                languageOverride = ttsPrefs?.get("languageOverride") as? String,
                 pitch = ttsPrefs?.get("pitch") as? Double,
                 speed = ttsPrefs?.get("speed") as? Double,
                 voices = voices,

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
@@ -5,6 +5,8 @@ import org.json.JSONObject
 import org.readium.navigator.media.tts.android.AndroidTtsEngine
 import org.readium.navigator.media.tts.android.AndroidTtsPreferences
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.InternalReadiumApi
+import org.readium.r2.shared.extensions.optNullableString
 import org.readium.r2.shared.util.Language
 
 /**
@@ -23,11 +25,13 @@ data class FlutterTtsPreferences(
      */
     @OptIn(ExperimentalReadiumApi::class)
     fun toAndroidTtsPreferences(): AndroidTtsPreferences {
-        val androidVoices = voices?.map { (lang, id) -> Language(lang) to AndroidTtsEngine.Voice.Id(id) }
-            ?.toMap()
+        val androidVoices =
+            voices?.map { (lang, id) -> Language(lang) to AndroidTtsEngine.Voice.Id(id) }
+                ?.toMap()
 
         // If no language in preferences, use the first language of the preferred voices.
-        val androidLanguage = language?.let { Language(it) } ?: androidVoices?.firstNotNullOfOrNull { it.key }
+        val androidLanguage =
+            language?.let { Language(it) } ?: androidVoices?.firstNotNullOfOrNull { it.key }
         return AndroidTtsPreferences(
             language = androidLanguage,
             pitch = pitch,
@@ -56,6 +60,7 @@ data class FlutterTtsPreferences(
         /**
          * Create FlutterTtsPreferences from JSON object.
          */
+        @OptIn(InternalReadiumApi::class)
         fun fromJSON(jsonObject: JSONObject): FlutterTtsPreferences {
             val voicesMap = mutableMapOf<String, String>()
             if (jsonObject.has("voices")) {
@@ -65,7 +70,7 @@ data class FlutterTtsPreferences(
                 }
             }
             return FlutterTtsPreferences(
-                language = jsonObject.optString("language", null),
+                language = jsonObject.optNullableString("language"),
                 pitch = jsonObject.optDouble("pitch").let { if (it.isNaN()) null else it },
                 speed = jsonObject.optDouble("speed").let { if (it.isNaN()) null else it },
                 voices = voicesMap.ifEmpty { null },
@@ -98,19 +103,38 @@ data class FlutterTtsPreferences(
         /**
          * Create FlutterTtsPreferences from a map.
          */
-        fun fromMap(prefs: Map<*, *>?): FlutterTtsPreferences {
-            val voices = (prefs?.get("voices") as? Map<*, *>)?.mapNotNull {
-                val key = it.key as? String
-                val value = it.value as? String
-                if (key != null && value != null) key to value else null
-            }?.toMap()
+        @OptIn(ExperimentalReadiumApi::class)
+        fun fromMap(
+            ttsPrefs: Map<*, *>?,
+            androidVoices: Set<AndroidTtsEngine.Voice>
+        ): FlutterTtsPreferences {
+            val voices = mutableMapOf<String, String>()
+
+            ttsPrefs?.let { prefs ->
+                (prefs["voiceIdentifier"] as? String)?.let { voiceId ->
+                    androidVoices.firstOrNull {
+                        it.id.value.equals(voiceId, true)
+                    }?.let {
+                        voices[it.language.code] = it.id.value
+                    }
+                }
+
+                (prefs["voices"] as? Map<*, *>?)?.forEach {
+                    val key = it.key as? String
+                    val value = it.value as? String
+                    if (key != null && value != null) {
+                        voices[key] = value
+                    }
+                }
+            }
+
             return FlutterTtsPreferences(
-                language = prefs?.get("language") as? String,
-                pitch = prefs?.get("pitch") as? Double,
-                speed = prefs?.get("speed") as? Double,
+                language = ttsPrefs?.get("language") as? String,
+                pitch = ttsPrefs?.get("pitch") as? Double,
+                speed = ttsPrefs?.get("speed") as? Double,
                 voices = voices,
                 controlPanelInfoType = ControlPanelInfoType.fromString(
-                    prefs?.get("controlPanelInfoType") as? String ?: "standard"
+                    ttsPrefs?.get("controlPanelInfoType") as? String ?: "standard"
                 )
             )
         }

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/FlutterTtsPreferences.kt
@@ -129,7 +129,8 @@ data class FlutterTtsPreferences(
             }
 
             return FlutterTtsPreferences(
-                language = ttsPrefs?.get("language") as? String,
+                language = (ttsPrefs?.get("languageOverride") as? String)
+                    ?: (ttsPrefs?.get("language") as? String),
                 pitch = ttsPrefs?.get("pitch") as? Double,
                 speed = ttsPrefs?.get("speed") as? Double,
                 voices = voices.ifEmpty { null },

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
@@ -102,14 +102,18 @@ internal class PublicationMethodCallHandler() :
             "ttsEnable" -> {
                 val args = arguments as Map<*, *>?
                 val ttsPrefs = FlutterTtsPreferences.fromMap(args, availableTtsVoices)
-                Log.d(TAG, "::ttsEnable: ttsPrefs:$ttsPrefs")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "::ttsEnable: ttsPrefs:$ttsPrefs")
+                }
                 return ttsEnable(ttsPrefs)
             }
 
             "ttsSetPreferences" -> {
                 val args = arguments as Map<*, *>?
                 val ttsPrefs = FlutterTtsPreferences.fromMap(args, availableTtsVoices)
-                Log.d(TAG, "::ttsSetPreferences: ttsPrefs:$ttsPrefs")
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "::ttsSetPreferences: ttsPrefs:$ttsPrefs")
+                }
 
                 return ttsSetPreferences(ttsPrefs)
             }

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
@@ -91,8 +91,6 @@ internal class PublicationMethodCallHandler() :
             }
 
             "closePublication" -> {
-                Log.d(TAG, "Close publication")
-
                 ReadiumReader.closePublication()
                 return Try.success(null)
             }
@@ -100,15 +98,12 @@ internal class PublicationMethodCallHandler() :
             "ttsEnable" -> {
                 val args = arguments as Map<*, *>?
                 val ttsPrefs = FlutterTtsPreferences.fromMap(args, ReadiumReader.ttsGetAvailableVoices())
-                Log.d(TAG, "::ttsEnable: ttsPrefs:$ttsPrefs")
                 return ttsEnable(ttsPrefs)
             }
 
             "ttsSetPreferences" -> {
                 val args = arguments as Map<*, *>?
                 val ttsPrefs = FlutterTtsPreferences.fromMap(args, ReadiumReader.ttsGetAvailableVoices())
-                Log.d(TAG, "::ttsSetPreferences: ttsPrefs:$ttsPrefs")
-
                 return ttsSetPreferences(ttsPrefs)
             }
 

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.launch
 import org.json.JSONObject
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.InternalReadiumApi
-import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.getOrElse
@@ -100,13 +99,15 @@ internal class PublicationMethodCallHandler() :
 
             "ttsEnable" -> {
                 val args = arguments as Map<*, *>?
-                val ttsPrefs = FlutterTtsPreferences.fromMap(args)
+                val ttsPrefs = FlutterTtsPreferences.fromMap(args, ReadiumReader.ttsGetAvailableVoices())
+                Log.d(TAG, "::ttsEnable: ttsPrefs:$ttsPrefs")
                 return ttsEnable(ttsPrefs)
             }
 
             "ttsSetPreferences" -> {
                 val args = arguments as Map<*, *>?
-                val ttsPrefs = FlutterTtsPreferences.fromMap(args)
+                val ttsPrefs = FlutterTtsPreferences.fromMap(args, ReadiumReader.ttsGetAvailableVoices())
+                Log.d(TAG, "::ttsSetPreferences: ttsPrefs:$ttsPrefs")
 
                 return ttsSetPreferences(ttsPrefs)
             }

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/PublicationChannel.kt
@@ -24,6 +24,8 @@ internal const val publicationChannelName = "dk.nota.flutter_readium/main"
 internal class PublicationMethodCallHandler() :
     MethodChannel.MethodCallHandler {
 
+    private val availableTtsVoices by lazy { ReadiumReader.ttsGetAvailableVoices() }
+
     @OptIn(InternalReadiumApi::class, ExperimentalReadiumApi::class)
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         CoroutineScope(Dispatchers.IO).launch {
@@ -99,14 +101,14 @@ internal class PublicationMethodCallHandler() :
 
             "ttsEnable" -> {
                 val args = arguments as Map<*, *>?
-                val ttsPrefs = FlutterTtsPreferences.fromMap(args, ReadiumReader.ttsGetAvailableVoices())
+                val ttsPrefs = FlutterTtsPreferences.fromMap(args, availableTtsVoices)
                 Log.d(TAG, "::ttsEnable: ttsPrefs:$ttsPrefs")
                 return ttsEnable(ttsPrefs)
             }
 
             "ttsSetPreferences" -> {
                 val args = arguments as Map<*, *>?
-                val ttsPrefs = FlutterTtsPreferences.fromMap(args, ReadiumReader.ttsGetAvailableVoices())
+                val ttsPrefs = FlutterTtsPreferences.fromMap(args, availableTtsVoices)
                 Log.d(TAG, "::ttsSetPreferences: ttsPrefs:$ttsPrefs")
 
                 return ttsSetPreferences(ttsPrefs)

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/ReadiumReader.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/ReadiumReader.kt
@@ -775,10 +775,21 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
         syncAudiobookNavigator?.decorationsUpdated()
     }
 
+    /**
+     * Cached list of android tts voices.
+     */
+    private var availableTtsVoices: Set<AndroidTtsEngine.Voice>? = null
+
+    /**
+     * Get available tts voices
+     */
     suspend fun ttsGetAvailableVoices(): Set<AndroidTtsEngine.Voice> {
+        // Already loaded, return existing list.
+        availableTtsVoices?.takeIf { it.isNotEmpty() }?.let { return it }
+
         // Get the available voices from the TTS navigator.
         // If the TTS navigator hasn't been initialized, create a dummy AndroidTtsEngine.
-        return ttsNavigator?.voices ?: AndroidTtsEngine.invoke(
+        availableTtsVoices = ttsNavigator?.voices ?: AndroidTtsEngine.invoke(
             context,
             {
                 AndroidTtsSettings(
@@ -791,7 +802,9 @@ object ReadiumReader : TimebasedNavigator.TimebasedListener, EpubNavigator.Visua
             },
             { language, availableVoices -> null },
             AndroidTtsPreferences()
-        )?.voices ?: setOf()
+        )?.voices
+
+        return availableTtsVoices ?: setOf()
     }
 
     fun ttsGetPreferences(): FlutterTtsPreferences? {

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/navigators/TimebasedNavigator.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/navigators/TimebasedNavigator.kt
@@ -2,13 +2,11 @@ package dk.nota.flutter_readium.navigators
 
 import android.util.Log
 import dk.nota.flutter_readium.PublicationError
-import kotlinx.coroutines.async
 import org.readium.navigator.media.common.MediaNavigator
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.publication.services.positions
 import kotlin.time.Duration
 
 private const val TAG = "TimebasedNavigator"

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/navigators/TimebasedNavigator.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutter_readium/navigators/TimebasedNavigator.kt
@@ -2,11 +2,13 @@ package dk.nota.flutter_readium.navigators
 
 import android.util.Log
 import dk.nota.flutter_readium.PublicationError
+import kotlinx.coroutines.async
 import org.readium.navigator.media.common.MediaNavigator
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.positions
 import kotlin.time.Duration
 
 private const val TAG = "TimebasedNavigator"

--- a/flutter_readium/example/lib/pages/bookshelf.page.dart
+++ b/flutter_readium/example/lib/pages/bookshelf.page.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';

--- a/flutter_readium/lib/reader_widget.dart
+++ b/flutter_readium/lib/reader_widget.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_readium/flutter_readium.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'reader_channel.dart';

--- a/flutter_readium_platform_interface/lib/src/reader/reader_audio_preferences.dart
+++ b/flutter_readium_platform_interface/lib/src/reader/reader_audio_preferences.dart
@@ -12,18 +12,10 @@ class AudioPreferences with EquatableMixin implements JSONable {
     final speed = jsonObject.optNullableDouble('speed', remove: true);
     final pitch = jsonObject.optNullableDouble('pitch', remove: true);
     final seekInterval = jsonObject.optNullableDouble('seekInterval', remove: true);
-    final allowExternalSeeking = jsonObject.optNullableBoolean(
-      'allowExternalSeeking',
-      remove: true,
-    );
+    final allowExternalSeeking = jsonObject.optNullableBoolean('allowExternalSeeking', remove: true);
     final updateIntervalSecs = jsonObject.optNullableDouble('updateIntervalSecs', remove: true);
-    final controlPanelInfoTypeStr = jsonObject.optNullableString(
-      'controlPanelInfoType',
-      remove: true,
-    );
-    final controlPanelInfoType = controlPanelInfoTypeStr?.let(
-      (it) => ControlPanelInfoType.fromString(it),
-    );
+    final controlPanelInfoTypeStr = jsonObject.optNullableString('controlPanelInfoType', remove: true);
+    final controlPanelInfoType = controlPanelInfoTypeStr?.let((it) => ControlPanelInfoType.fromOptString(it));
     return AudioPreferences(
       volume: volume,
       speed: speed,
@@ -101,6 +93,6 @@ enum ControlPanelInfoType {
   chapterTitle,
   titleChapter;
 
-  static ControlPanelInfoType? fromString(final String type) =>
+  static ControlPanelInfoType? fromOptString(final String type) =>
       ControlPanelInfoType.values.firstWhereOrNull((e) => e.toString().split('.').last == type);
 }

--- a/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
+++ b/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
@@ -17,11 +17,11 @@ class TTSPreferences implements JSONable {
     ControlPanelInfoType? controlPanelInfoType;
 
     if (controlPanelInfoTypeStr != null) {
-      try {
-        controlPanelInfoType = ControlPanelInfoType.fromOptString(controlPanelInfoTypeStr);
-      } catch (e) {
-        Fimber.w('Unknown ControlPanelInfoType value: $controlPanelInfoTypeStr, defaulting to null.', ex: e);
-        controlPanelInfoType = null;
+      controlPanelInfoType = ControlPanelInfoType.fromOptString(controlPanelInfoTypeStr);
+      if (controlPanelInfoType == null) {
+        Fimber.w(
+          'Unknown ControlPanelInfoType value: $controlPanelInfoTypeStr, defaulting to ControlPanelInfoType.standard.',
+        );
       }
     }
 

--- a/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
+++ b/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
@@ -10,14 +10,15 @@ class TTSPreferences implements JSONable {
     final speed = jsonObject.optDouble('speed', remove: true);
     final pitch = jsonObject.optDouble('pitch', remove: true);
     final voiceIdentifier = jsonObject.optNullableString('voiceIdentifier', remove: true);
+    final voicesJson = jsonObject.optJsonObject('voices', remove: true) ?? {};
+    final voices = voicesJson.map((key, value) => MapEntry(key, value.toString()));
     final languageOverride = jsonObject.optNullableString('languageOverride', remove: true);
     final controlPanelInfoTypeStr = jsonObject.optNullableString('controlPanelInfoType', remove: true);
     ControlPanelInfoType? controlPanelInfoType;
 
     if (controlPanelInfoTypeStr != null) {
       try {
-        controlPanelInfoType = ControlPanelInfoType.values.byName(controlPanelInfoTypeStr);
-        // ignore: avoid_catches_without_on_clauses
+        controlPanelInfoType = ControlPanelInfoType.fromOptString(controlPanelInfoTypeStr);
       } catch (e) {
         Fimber.w('Unknown ControlPanelInfoType value: $controlPanelInfoTypeStr, defaulting to null.', ex: e);
         controlPanelInfoType = null;
@@ -28,8 +29,9 @@ class TTSPreferences implements JSONable {
       speed: speed,
       pitch: pitch,
       voiceIdentifier: voiceIdentifier,
+      voices: voices,
       languageOverride: languageOverride,
-      controlPanelInfoType: controlPanelInfoType,
+      controlPanelInfoType: controlPanelInfoType ?? ControlPanelInfoType.standard,
     );
   }
 
@@ -37,22 +39,35 @@ class TTSPreferences implements JSONable {
     this.speed,
     this.pitch,
     this.voiceIdentifier,
+    this.voices = const {},
     this.languageOverride,
     this.controlPanelInfoType,
   });
 
+  /// The speech rate (speed) for text-to-speech. A value of 1.0 is the normal speed, less than 1.0 is slower, and greater than 1.0 is faster.
   final double? speed;
+
+  /// The pitch for text-to-speech. A value of 1.0 is the normal pitch, less than 1.0 is lower, and greater than 1.0 is higher.
   final double? pitch;
+
+  /// The identifier of the voice to use for text-to-speech. This should correspond to one of the available voices returned by [ttsGetAvailableVoices].
   final String? voiceIdentifier;
+
+  /// More detailed voice settings for Android, where you can set a voice per language.
+  final Map<String, String> voices;
+
+  /// Force language for TTS, ignoring the language specified in the publication.
   final String? languageOverride;
+
+  /// Control panel info type to determine what information is sent to the control panel during TTS playback.
   final ControlPanelInfoType? controlPanelInfoType;
 
   @override
-  Map<String, dynamic> toJson() => {
-    'speed': speed,
-    'pitch': pitch,
-    'voiceIdentifier': voiceIdentifier,
-    'languageOverride': languageOverride,
-    'controlPanelInfoType': controlPanelInfoType?.toString().split('.').last,
-  };
+  Map<String, dynamic> toJson() => {}
+    ..putOpt('speed', speed)
+    ..putOpt('pitch', pitch)
+    ..putOpt('voiceIdentifier', voiceIdentifier)
+    ..putMapIfNotEmpty('voices', voices)
+    ..putOpt('languageOverride', languageOverride)
+    ..putOpt('controlPanelInfoType', controlPanelInfoType?.toString().split('.').last);
 }

--- a/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
+++ b/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
@@ -11,17 +11,21 @@ class TTSPreferences implements JSONable {
     final pitch = jsonObject.optDouble('pitch', remove: true);
     final voiceIdentifier = jsonObject.optNullableString('voiceIdentifier', remove: true);
     final voicesJson = jsonObject.optJsonObject('voices', remove: true) ?? {};
-    final voices = voicesJson.map((key, value) => MapEntry(key, value.toString()));
+    final Map<String, String> voices = Map.fromEntries(
+      voicesJson.entries
+          .where((entry) => entry.value is String)
+          .map((entry) => MapEntry(entry.key, entry.value as String)),
+    );
     final languageOverride = jsonObject.optNullableString('languageOverride', remove: true);
     final controlPanelInfoTypeStr = jsonObject.optNullableString('controlPanelInfoType', remove: true);
     ControlPanelInfoType? controlPanelInfoType;
 
     if (controlPanelInfoTypeStr != null) {
-      try {
-        controlPanelInfoType = ControlPanelInfoType.fromOptString(controlPanelInfoTypeStr);
-      } catch (e) {
-        Fimber.w('Unknown ControlPanelInfoType value: $controlPanelInfoTypeStr, defaulting to null.', ex: e);
-        controlPanelInfoType = null;
+      controlPanelInfoType = ControlPanelInfoType.fromOptString(controlPanelInfoTypeStr);
+      if (controlPanelInfoType == null) {
+        Fimber.w(
+          'Unknown ControlPanelInfoType value: $controlPanelInfoTypeStr, defaulting to ControlPanelInfoType.standard.',
+        );
       }
     }
 

--- a/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
+++ b/flutter_readium_platform_interface/lib/src/reader/reader_tts_preferences.dart
@@ -11,7 +11,11 @@ class TTSPreferences implements JSONable {
     final pitch = jsonObject.optDouble('pitch', remove: true);
     final voiceIdentifier = jsonObject.optNullableString('voiceIdentifier', remove: true);
     final voicesJson = jsonObject.optJsonObject('voices', remove: true) ?? {};
-    final voices = voicesJson.map((key, value) => MapEntry(key, value.toString()));
+    final Map<String, String> voices = Map.fromEntries(
+      voicesJson.entries
+          .where((entry) => entry.value is String)
+          .map((entry) => MapEntry(entry.key, entry.value as String)),
+    );
     final languageOverride = jsonObject.optNullableString('languageOverride', remove: true);
     final controlPanelInfoTypeStr = jsonObject.optNullableString('controlPanelInfoType', remove: true);
     ControlPanelInfoType? controlPanelInfoType;


### PR DESCRIPTION
This was caused by differences between swift and kotlin.

In Swift we can only set a voiceIdentifier but in kotlin, we can set a voice per language.

We need to discus how to best handle these differences.

This PR adds support in kotlin for a single voiceIdentifier and adds the voices map to the dart layer's TTSPreferences.