### PR TITLE
fix: Fix compile errors when using Flutter 3.44

### DIFF
--- a/flutter_readium/ios/flutter_readium/Package.swift
+++ b/flutter_readium/ios/flutter_readium/Package.swift
@@ -8,14 +8,14 @@ let package = Package(
     // TODO: Update your plugin name.
     name: "flutter_readium",
     platforms: [
-        .iOS("13.4"),
+        .iOS("15.0"),
         .macOS("10.15")
     ],
     products: [
         .library(name: "flutter-readium", targets: ["flutter_readium"])
     ],
     dependencies: [
-      .package(url: "https://github.com/readium/swift-toolkit.git", .upToNextMinor(from: "3.5.0")),
+      .package(url: "https://github.com/readium/swift-toolkit.git", .upToNextMinor(from: "3.7.0")),
       .package(url: "https://github.com/mxcl/PromiseKit", .upToNextMinor(from: "6.8.0"))
     ],
     targets: [

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/Readium.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/Readium.swift
@@ -9,6 +9,7 @@ import ReadiumAdapterGCDWebServer
 import ReadiumNavigator
 import ReadiumShared
 import ReadiumStreamer
+import UIKit
 
 #if LCP
 import R2LCPClient

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/FlutterAudioPreferences.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/FlutterAudioPreferences.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct FlutterAudioPreferences {
   public var volume: Double
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/FlutterMediaOverlay.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/FlutterMediaOverlay.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumShared
 
 struct FlutterMediaOverlay {

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/ReadiumTimeBasedState.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/ReadiumTimeBasedState.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumShared
 
 public enum TimebasedState: String {

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/TextSearchResult.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/model/TextSearchResult.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumShared
 
 struct TextSearchResult {

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterAudioNavigator.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterAudioNavigator.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import MediaPlayer
 import ReadiumShared
 import ReadiumNavigator

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterMediaOverlayNavigator.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterMediaOverlayNavigator.swift
@@ -5,6 +5,7 @@
 //  Created by Daniel Dam Freiling on 29/10/2025.
 //
 
+import Foundation
 import ReadiumShared
 import ReadiumNavigator
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterTimebasedNavigator.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterTimebasedNavigator.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import ReadiumShared
 
 public protocol TimebasedListener {


### PR DESCRIPTION
Flutter just released version 3.44, and when using the _flutter_readium_ package in a project that uses this version, compilation errors occured. This fix solves them by:
- Explicitly import previously transitive imports.
- Specify the correct iOS and _swift-toolkit_ versions in `Package.swift`. 