### PR TITLE
change int to double in font size

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Example app EPUB font-size preferences now convert the persisted percentage
+  value to the scale expected by Android/Web and keep `typeScale` in sync.
+
 ### Added
 
 - **Text selection callback** — `ReadiumReaderWidget.onTextSelected` fires a

--- a/flutter_readium/example/lib/state/text_settings_bloc.dart
+++ b/flutter_readium/example/lib/state/text_settings_bloc.dart
@@ -226,62 +226,44 @@ class TextSettingsState {
 class TextSettingsBloc extends Bloc<TextSettingsEvent, TextSettingsState> {
   final FlutterReadium instance = FlutterReadium();
 
-  void submitPreferenceUpdate() async {
-    final epubPreferences = EPUBPreferences(
-      fontFamily: state.fontFamily,
-      fontSize: state.fontSize,
-      fontWeight: state.fontWeight,
-      scroll: state.scroll,
-      backgroundColor: state.theme.backgroundColor,
-      textColor: state.theme.textColor,
-      pageMargins: state.pageMargins,
-      paragraphSpacing: state.paragraphSpacing,
-      publisherStyles: state.publisherStyles,
-      blackAndWhiteComicMode: state.blackAndWhiteComicMode,
-      disableSynchronization: state.disableSynchronization,
-      firstElementTopMargin: state.firstElementTopMargin,
-      letterSpacing: state.letterSpacing,
-      wordSpacing: state.wordSpacing,
-      lineHeight: state.lineHeight,
-      textAlign: state.textAlign,
-      columnCount: state.columnCount,
-      readingProgression: state.readingProgression,
-      paragraphIndent: state.paragraphIndent,
-      hyphens: state.hyphens,
-      ligatures: state.ligatures,
-      textNormalization: state.textNormalization,
-      imageFilter: state.imageFilter,
+  EPUBPreferences buildPreferences(final TextSettingsState settings) {
+    final clampedFontSize = settings.fontSize.clamp(70, 200);
+    final fontScale = clampedFontSize / 100.0;
+
+    return EPUBPreferences(
+      fontFamily: settings.fontFamily,
+      fontSize: defaultTargetPlatform == TargetPlatform.iOS ? clampedFontSize.toDouble() : fontScale,
+      typeScale: fontScale,
+      fontWeight: settings.fontWeight,
+      scroll: settings.scroll,
+      backgroundColor: settings.theme.backgroundColor,
+      textColor: settings.theme.textColor,
+      pageMargins: settings.pageMargins,
+      paragraphSpacing: settings.paragraphSpacing,
+      publisherStyles: settings.publisherStyles,
+      blackAndWhiteComicMode: settings.blackAndWhiteComicMode,
+      disableSynchronization: settings.disableSynchronization,
+      firstElementTopMargin: settings.firstElementTopMargin,
+      letterSpacing: settings.letterSpacing,
+      wordSpacing: settings.wordSpacing,
+      lineHeight: settings.lineHeight,
+      textAlign: settings.textAlign,
+      columnCount: settings.columnCount,
+      readingProgression: settings.readingProgression,
+      paragraphIndent: settings.paragraphIndent,
+      hyphens: settings.hyphens,
+      ligatures: settings.ligatures,
+      textNormalization: settings.textNormalization,
+      imageFilter: settings.imageFilter,
     );
-    instance.setEPUBPreferences(epubPreferences);
+  }
+
+  void submitPreferenceUpdate() async {
+    instance.setEPUBPreferences(buildPreferences(state));
   }
 
   void setDefaultPreferences() {
-    final defaultPreferences = EPUBPreferences(
-      fontFamily: state.fontFamily,
-      fontSize: state.fontSize,
-      fontWeight: state.fontWeight,
-      scroll: state.scroll,
-      backgroundColor: state.theme.backgroundColor,
-      textColor: state.theme.textColor,
-      pageMargins: state.pageMargins,
-      paragraphSpacing: state.paragraphSpacing,
-      publisherStyles: state.publisherStyles,
-      blackAndWhiteComicMode: state.blackAndWhiteComicMode,
-      disableSynchronization: state.disableSynchronization,
-      firstElementTopMargin: state.firstElementTopMargin,
-      letterSpacing: state.letterSpacing,
-      wordSpacing: state.wordSpacing,
-      lineHeight: state.lineHeight,
-      textAlign: state.textAlign,
-      columnCount: state.columnCount,
-      readingProgression: state.readingProgression,
-      paragraphIndent: state.paragraphIndent,
-      hyphens: state.hyphens,
-      ligatures: state.ligatures,
-      textNormalization: state.textNormalization,
-      imageFilter: state.imageFilter,
-    );
-    instance.setDefaultPreferences(defaultPreferences);
+    instance.setDefaultPreferences(buildPreferences(state));
   }
 
   TextSettingsBloc()

--- a/flutter_readium_platform_interface/lib/src/reader/reader_epub_preferences.dart
+++ b/flutter_readium_platform_interface/lib/src/reader/reader_epub_preferences.dart
@@ -48,7 +48,7 @@ class EPUBPreferences with EquatableMixin implements JSONable {
   final String? fontFamily;
 
   /// Font size for text content.
-  final int? fontSize;
+  final double? fontSize;
 
   /// Font weight for text content.
   final double? fontWeight;
@@ -131,7 +131,7 @@ class EPUBPreferences with EquatableMixin implements JSONable {
     final columnCountStr = jsonObject.optNullableString('columnCount', remove: true);
     final columnCount = columnCountStr != null ? EpubColumnCount.fromJson(columnCountStr) : null;
     final fontFamily = jsonObject.optNullableString('fontFamily', remove: true);
-    final fontSize = jsonObject.optNullableInt('fontSize', remove: true);
+    final fontSize = jsonObject.optNullableDouble('fontSize', remove: true);
     final fontWeight = jsonObject.optNullableDouble('fontWeight', remove: true);
     final hyphens = jsonObject.optNullableBoolean('hyphens', remove: true);
     final imageFilterStr = jsonObject.optNullableString('imageFilter', remove: true);
@@ -226,7 +226,7 @@ class EPUBPreferences with EquatableMixin implements JSONable {
     Color? backgroundColor,
     EpubColumnCount? columnCount,
     String? fontFamily,
-    int? fontSize,
+    double? fontSize,
     double? fontWeight,
     bool? hyphens,
     EpubImageFilter? imageFilter,
@@ -315,7 +315,8 @@ class EPUBPreferences with EquatableMixin implements JSONable {
 enum EpubColumnCount {
   auto,
   one,
-  two;
+  two
+  ;
 
   static EpubColumnCount? fromJson(String? value) {
     switch (value) {
@@ -344,7 +345,8 @@ enum EpubColumnCount {
 
 enum EpubImageFilter {
   darken,
-  invert;
+  invert
+  ;
 
   static EpubImageFilter? fromJson(String? value) {
     switch (value) {
@@ -369,7 +371,8 @@ enum EpubImageFilter {
 
 enum EpubReadingProgression {
   ltr,
-  rtl;
+  rtl
+  ;
 
   static EpubReadingProgression? fromJson(String? value) {
     switch (value) {


### PR DESCRIPTION
The app stores reader font size as a percentage for UI/persistence, but Readium Android/Web expects fontSize as a scale value. Passing 100.0 compiles but does not behave correctly; it should be sent as 1.0. iOS currently divides fontSize by 100 in the native bridge, so it still receives the percentage value. typeScale should also be updated from the same scale so the rendered text actually changes with the slider.





EPUBPreferences buildPreferences(TextSettingsState settings) {
  final clampedFontSize = settings.fontSize.clamp(70, 200);
  final fontScale = clampedFontSize / 100.0;

  return EPUBPreferences(
    // UI stores font size as percent: 70, 100, 150, 200.
    // Android/Web Readium expects scale: 0.7, 1.0, 1.5, 2.0.
    // iOS bridge currently divides fontSize by 100 internally.
    fontSize: defaultTargetPlatform == TargetPlatform.iOS
        ? clampedFontSize.toDouble()
        : fontScale,

    // Keep typeScale in sync with the selected font size.
    typeScale: fontScale,

    publisherStyles: false,
    fontFamily: settings.fontFamily,
    lineHeight: settings.lineHeight,
    letterSpacing: settings.letterSpacing,
  );
}