### PR TITLE
fix(iOS): integration test flakiness

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -11,11 +11,13 @@ supporting cross-platform additions.
 
 ### Fixed
 
-- **iOS: early reader events are no longer dropped** — the native event-channel
-  bridge now buffers the latest event until Dart finishes attaching its
-  listener, so mount-time `onTextLocatorChanged` / `onReaderStatusChanged`
-  emissions are delivered reliably even when the platform view starts faster
-  than the stream subscription handshake.
+- **iOS: early reader events are no longer dropped** — the `text-locator` and
+  `reader-status` event channels now buffer the most-recent event on the native
+  side when Dart has not yet attached a listener.  The buffer is flushed
+  immediately when `onListen` fires, eliminating the race between the EPUB
+  platform-view initialisation and the asynchronous stream-subscription
+  handshake.  Buffers are cleared on `closePublication()` so stale events from
+  a closed publication are never replayed to the next subscriber.
 
 ### Added
 

--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -9,6 +9,14 @@ Brings the Web platform up to feature parity with iOS / Android (audio,
 Media Overlay, TTS, Guided Navigation, decorations), plus a handful of
 supporting cross-platform additions.
 
+### Fixed
+
+- **iOS: early reader events are no longer dropped** — the native event-channel
+  bridge now buffers the latest event until Dart finishes attaching its
+  listener, so mount-time `onTextLocatorChanged` / `onReaderStatusChanged`
+  emissions are delivered reliably even when the platform view starts faster
+  than the stream subscription handshake.
+
 ### Added
 
 - **Web: Audio Navigator** — audiobook publications now play on web. `audioEnable`,

--- a/flutter_readium/example/integration_test/plugin_integration_test.dart
+++ b/flutter_readium/example/integration_test/plugin_integration_test.dart
@@ -94,6 +94,7 @@ void main() {
       timeout: const Duration(seconds: 30),
       reason: 'ReadiumReaderWidget never emitted an initial textLocator',
     );
+    await _waitForListStable(tester, locators);
     final initialLocator = locators.last;
 
     // The reader should have emitted ready now that we have received the first Locator.
@@ -111,6 +112,7 @@ void main() {
       timeout: const Duration(seconds: 15),
       reason: 'goForward() did not produce a new textLocator',
     );
+    await _waitForListStable(tester, locators);
     expect(
       locators.last,
       isNot(equals(initialLocator)),
@@ -489,6 +491,7 @@ void main() {
         timeout: const Duration(seconds: 30),
         reason: 'No initial textLocator emitted',
       );
+      await _waitForListStable(tester, locators);
       final savedLocator = locators.last;
 
       await reader.goForward();
@@ -498,6 +501,7 @@ void main() {
         timeout: const Duration(seconds: 30),
         reason: 'goForward() did not produce a new locator',
       );
+      await _waitForListStable(tester, locators);
       final afterForward = locators.last;
 
       final ok = await reader.goToLocator(savedLocator);
@@ -509,6 +513,7 @@ void main() {
         timeout: const Duration(seconds: 30),
         reason: 'goToLocator() did not emit a new textLocator',
       );
+      await _waitForListStable(tester, locators);
       expect(
         locators.last.href,
         equals(savedLocator.href),
@@ -540,13 +545,16 @@ void main() {
         timeout: const Duration(seconds: 30),
         reason: 'No initial locator on first mount',
       );
+      await _waitForListStable(tester, locators);
+      final initialLocator = locators.last;
       await reader.goForward();
       await _waitWithPump(
         tester,
-        () => locators.length >= 2,
+        () => locators.last != initialLocator,
         timeout: const Duration(seconds: 15),
-        reason: 'goForward() did not emit a second locator',
+        reason: 'goForward() did not advance from the initial locator',
       );
+      await _waitForListStable(tester, locators);
       final savedLocator = locators.last;
 
       // Unmount, then remount with initialLocator.
@@ -568,6 +576,7 @@ void main() {
         timeout: const Duration(seconds: 30),
         reason: 'No textLocator emitted after remount with initialLocator',
       );
+      await _waitForListStable(tester, locators);
 
       expect(
         locators.last.href,

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/FlutterReadiumPlugin.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/FlutterReadiumPlugin.swift
@@ -54,8 +54,11 @@ public class FlutterReadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.Warnin
     let plugin = FlutterReadiumPlugin()
     registrar.addMethodCallDelegate(plugin, channel: channel)
     plugin.timebasedPlayerStateStreamHandler = EventStreamHandler(withName: "timebased-state", messenger: registrar.messenger())
-    plugin.textLocatorStreamHandler = EventStreamHandler(withName: "text-locator", messenger: registrar.messenger())
-    plugin.readerStatusStreamHandler = EventStreamHandler(withName: "reader-status", messenger: registrar.messenger())
+    // text-locator and reader-status opt in to buffering: the EPUB platform view
+    // can fire its first event before the Dart onListen handshake completes, so
+    // the buffer ensures that event is never silently dropped.
+    plugin.textLocatorStreamHandler = EventStreamHandler(withName: "text-locator", messenger: registrar.messenger(), bufferLatestEvent: true)
+    plugin.readerStatusStreamHandler = EventStreamHandler(withName: "reader-status", messenger: registrar.messenger(), bufferLatestEvent: true)
     plugin.errorStreamHandler = EventStreamHandler(withName: "error", messenger: registrar.messenger())
     instance = plugin
 
@@ -678,6 +681,10 @@ extension FlutterReadiumPlugin {
     currentPublication = nil
     currentPublicationUrlStr = nil
     currentPublicationCssSelectorMap = [:]
+    // Clear the stream buffers so that a subscriber opening the next publication
+    // never receives a stale locator or status from this closed publication.
+    textLocatorStreamHandler?.clearBuffer()
+    readerStatusStreamHandler?.clearBuffer()
   }
 }
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/utils/EventStreamHandler.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/utils/EventStreamHandler.swift
@@ -1,27 +1,53 @@
 import Flutter
 
+/// Buffering contract (keep platforms aligned):
+///
+/// On iOS the `FlutterEventChannel` `onListen` handshake is asynchronous and
+/// can complete *after* the EPUB platform-view has already fired its first
+/// `locationDidChange`, silently dropping that event. Android and Web are
+/// immune by construction — Android emits the first locator only after
+/// `onPageLoaded` (long after the Dart handshake) and dispatches via a
+/// coroutine, and Web uses in-process `StreamController`s with no handshake.
+/// `bufferLatestEvent` brings iOS into line with that guarantee.
+///
+/// Rule of thumb for whether a channel should buffer:
+///   - Buffer **state-like** streams, where the latest value is meaningful to a
+///     late subscriber (`text-locator`, `reader-status`).
+///   - Do NOT buffer **event-like / sentinel** streams, where replaying the last
+///     value to a new subscriber is wrong (`timebased-state` emits a `.none`
+///     sentinel on `closePublication()`; `error` is a one-shot notification).
+/// Buffered streams must be cleared on `closePublication()` so a stale value
+/// from a closed publication is never replayed to the next one.
 class EventStreamHandler: NSObject, FlutterStreamHandler {
 
   private let streamName: String
   private var channel: FlutterEventChannel
   private var eventSink: FlutterEventSink?
-  private var bufferedEvent: Any?
+
+  // When true, the most recent event is held in `bufferedEvent` whenever
+  // the Dart subscriber is not yet attached (eventSink == nil). The buffer
+  // is flushed immediately on onListen so the subscriber never misses the
+  // first event despite the async channel-handshake timing. See the
+  // class-level buffering contract above for which streams should opt in.
+  private let bufferLatestEvent: Bool
+  // Any?? distinguishes "nothing buffered" (nil) from "nil was buffered" (.some(.none)).
+  private var bufferedEvent: Any?? = nil
 
   public func sendEvent(_ event: Any?) {
-    guard let eventSink else {
-      bufferedEvent = event
-      return
+    if let sink = eventSink {
+      sink(event)
+    } else if bufferLatestEvent {
+      bufferedEvent = .some(event)
     }
-
-    eventSink(event)
   }
 
   func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
     Log.readium.debug("StreamHandler.onListen: \(self.streamName)")
     eventSink = events
-    if let bufferedEvent {
-      events(bufferedEvent)
-      self.bufferedEvent = nil
+    // Flush any event that arrived before Dart had a chance to subscribe.
+    if let event = bufferedEvent {
+      events(event)
+      bufferedEvent = nil
     }
     return nil
   }
@@ -29,8 +55,15 @@ class EventStreamHandler: NSObject, FlutterStreamHandler {
   func onCancel(withArguments arguments: Any?) -> FlutterError? {
     Log.readium.debug("StreamHandler.onCancel: \(self.streamName)")
     eventSink = nil
-    bufferedEvent = nil
     return nil
+  }
+
+  /// Discards any buffered event without delivering it.
+  ///
+  /// Call this on `closePublication()` so that the last event from a closed
+  /// publication is never replayed to the subscriber of the next publication.
+  func clearBuffer() {
+    bufferedEvent = nil
   }
 
   func dispose() {
@@ -42,8 +75,9 @@ class EventStreamHandler: NSObject, FlutterStreamHandler {
     channel.setStreamHandler(nil)
   }
 
-  init(withName streamName: String, messenger: FlutterBinaryMessenger) {
+  init(withName streamName: String, messenger: FlutterBinaryMessenger, bufferLatestEvent: Bool = false) {
     self.streamName = streamName
+    self.bufferLatestEvent = bufferLatestEvent
     channel = FlutterEventChannel(name: "dk.nota.flutter_readium/\(streamName)", binaryMessenger: messenger)
     super.init()
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/utils/EventStreamHandler.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/utils/EventStreamHandler.swift
@@ -5,20 +5,31 @@ class EventStreamHandler: NSObject, FlutterStreamHandler {
   private let streamName: String
   private var channel: FlutterEventChannel
   private var eventSink: FlutterEventSink?
+  private var bufferedEvent: Any?
 
   public func sendEvent(_ event: Any?) {
-    eventSink?(event)
+    guard let eventSink else {
+      bufferedEvent = event
+      return
+    }
+
+    eventSink(event)
   }
 
   func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
     Log.readium.debug("StreamHandler.onListen: \(self.streamName)")
     eventSink = events
+    if let bufferedEvent {
+      events(bufferedEvent)
+      self.bufferedEvent = nil
+    }
     return nil
   }
 
   func onCancel(withArguments arguments: Any?) -> FlutterError? {
     Log.readium.debug("StreamHandler.onCancel: \(self.streamName)")
     eventSink = nil
+    bufferedEvent = nil
     return nil
   }
 
@@ -27,6 +38,7 @@ class EventStreamHandler: NSObject, FlutterStreamHandler {
     // End stream and clear the event-sink to prevent memory leaks.
     eventSink?(FlutterEndOfEventStream)
     eventSink = nil
+    bufferedEvent = nil
     channel.setStreamHandler(nil)
   }
 

--- a/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
+++ b/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
@@ -30,20 +30,22 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
   EventChannel readerStatusChannel = const EventChannel('dk.nota.flutter_readium/reader-status');
 
   Stream<Locator>? _onTextLocatorChanged;
-
   Stream<ReadiumTimebasedState>? _onTimebasedPlayerStateChanged;
-
   Stream<ReadiumReaderStatus>? _onReaderStatusChanged;
-
   Stream<ReadiumError>? _onErrorEvent;
 
   /// Fires whenever the Reader's current Locator changes.
+  ///
+  /// The underlying event channel opts in to native-side buffering so the first
+  /// event is never dropped even if it fires before the Dart [onListen]
+  /// handshake completes (a race that can happen when the EPUB platform view
+  /// initialises faster than the asynchronous channel setup).
   @override
   Stream<Locator> get onTextLocatorChanged {
-    _onTextLocatorChanged ??= textLocatorChannel.receiveBroadcastStream().map((dynamic event) {
-      final newLocator = Locator.fromJson(json.decode(event) as Map<String, dynamic>);
-      return newLocator!;
-    }).asBroadcastStream();
+    _onTextLocatorChanged ??= textLocatorChannel
+        .receiveBroadcastStream()
+        .map((dynamic event) => Locator.fromJson(json.decode(event) as Map<String, dynamic>)!)
+        .asBroadcastStream();
     return _onTextLocatorChanged!;
   }
 
@@ -67,6 +69,10 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
     return _onTimebasedPlayerStateChanged!;
   }
 
+  /// Fires whenever the reader status changes.
+  ///
+  /// Like [onTextLocatorChanged], the underlying event channel opts in to
+  /// native-side buffering to avoid dropping the first status event.
   @override
   Stream<ReadiumReaderStatus> get onReaderStatusChanged {
     _onReaderStatusChanged ??= readerStatusChannel.receiveBroadcastStream().map((dynamic event) {
@@ -79,7 +85,7 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
         _log.w('Error parsing reader status event: $e');
         return ReadiumReaderStatus.error;
       }
-    });
+    }).asBroadcastStream();
     return _onReaderStatusChanged!;
   }
 
@@ -123,7 +129,15 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
   }
 
   @override
-  Future<void> closePublication() async => await methodChannel.invokeMethod<void>('closePublication');
+  Future<void> closePublication() async {
+    await methodChannel.invokeMethod<void>('closePublication');
+    // Reset the lazy-stream fields so the next getter access creates a fresh
+    // subscription and fires onListen on native before the next book's widget
+    // mounts. The native side clears its event buffers in the same call, so no
+    // stale locator or status from this publication will be replayed.
+    _onTextLocatorChanged = null;
+    _onReaderStatusChanged = null;
+  }
 
   @override
   Future<void> goBackward() async => await currentReaderWidget?.goBackward();


### PR DESCRIPTION
## Problem

The iOS integration tests were intermittently failing on CI (e.g. `goToLocator round-trips back to a saved position` — "No initial textLocator emitted", and the TTS test with a `TimeoutException`).

**Root cause (iOS-specific):** the `FlutterEventChannel` `onListen` handshake is asynchronous and can complete *after* the freshly-mounted EPUB platform view has already fired its first `locationDidChange`. With a nil `eventSink` at that moment, the first `text-locator` / `reader-status` event was silently dropped — so a test (or app) subscribing around mount time never saw the initial locator.

Android and Web are structurally immune: Android only emits the first locator after `onPageLoaded` (well after the Dart handshake) and dispatches via a coroutine, and Web uses in-process `StreamController`s with no channel handshake.

## Fix

- **Native buffering (opt-in)** — `EventStreamHandler` buffers the latest event when no Dart subscriber is attached and flushes it on `onListen`. Only `text-locator` and `reader-status` opt in; `timebased-state` and `error` must **not** buffer (they carry one-shot / sentinel values such as the `.none` state emitted on close).
- **Clear buffers on close** — `closePublication()` clears the buffered locator/status so a stale value from a closed publication is never replayed to the next one.
- **Reset Dart streams on close** — the lazy stream fields are nulled in `closePublication()`, so the next getter access re-establishes the native `onListen` handshake before the next book's widget mounts.
- **`onReaderStatusChanged` is now a broadcast stream** — supports multiple subscribers (previously single-subscription).
- **Documented the buffering contract** on `EventStreamHandler`: buffer *state-like* streams, never *event-like / sentinel* streams; clear buffered streams on close.

## Testing

All 22 integration tests pass on iOS, including the previously-flaky `goToLocator round-trips`, `initialLocator restores`, and `opens EPUB and enables TTS`.

No Android or Web changes.