### PR TITLE
feat: improve example-app settings & controls

### DIFF
--- a/flutter_readium/example/integration_test/plugin_integration_test.dart
+++ b/flutter_readium/example/integration_test/plugin_integration_test.dart
@@ -1089,7 +1089,135 @@ void main() {
       );
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Fully-wired ReadiumReaderWidget smoke test
+  //
+  // Mounts the reader with the same configuration
+  // example/lib/widgets/reader.widget.dart uses in production — selection
+  // actions, decoration/selection callbacks, a real drag gesture — for one
+  // fixture per content type/navigator. Only asserts "renders without
+  // crashing"; no feature is exercised in depth.
+  // ---------------------------------------------------------------------------
+
+  group('Fully-wired ReadiumReaderWidget smoke test', () {
+    Future<void> mountFullyWiredAndSmokeTest(
+      WidgetTester tester,
+      Publication pub, {
+      required String reason,
+    }) async {
+      final locators = <Locator>[];
+      final sub = reader.onTextLocatorChanged.listen(locators.add);
+      addTearDown(sub.cancel);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: _fullyWiredReaderWidget(pub)),
+        ),
+      );
+      await _waitWithPump(
+        tester,
+        () => locators.isNotEmpty,
+        timeout: const Duration(seconds: 30),
+        reason: reason,
+      );
+
+      // Exercise the gesture-driven notifyUserNavigation path: a plain
+      // center-tap toggles controls instead (see reader_widget.dart
+      // `_onInteraction`), only a drag past the ~3px swipe threshold reaches it.
+      await tester.drag(find.byType(ReadiumReaderWidget), const Offset(20, 0));
+      await tester.pump();
+
+      await tester.pumpWidget(const SizedBox());
+    }
+
+    testWidgets('EPUB', (tester) async {
+      final path = fixturePaths['moby_dick.epub'];
+      expect(path, isNotNull, reason: 'Fixture moby_dick.epub missing from asset bundle');
+
+      final pub = await reader.openPublication(path!);
+      await mountFullyWiredAndSmokeTest(
+        tester,
+        pub,
+        reason: 'Fully-wired EPUB reader never emitted an initial textLocator',
+      );
+    });
+
+    testWidgets(
+      'PDF',
+      // PDF not supported on web.
+      skip: kIsWeb,
+      (tester) async {
+        final path = fixturePaths['time_machine.pdf'];
+        expect(path, isNotNull, reason: 'Fixture time_machine.pdf missing from asset bundle');
+
+        final pub = await reader.openPublication(path!);
+        await mountFullyWiredAndSmokeTest(
+          tester,
+          pub,
+          reason: 'Fully-wired PDF reader never emitted an initial textLocator',
+        );
+      },
+    );
+
+    testWidgets('WebPub with Media Overlay', (tester) async {
+      final path = fixturePaths['38533_overlay_preview.webpub'];
+      expect(path, isNotNull, reason: 'Fixture 38533_overlay_preview.webpub missing from asset bundle');
+
+      final pub = await reader.openPublication(path!);
+      await mountFullyWiredAndSmokeTest(
+        tester,
+        pub,
+        reason: 'Fully-wired media-overlay reader never emitted an initial textLocator',
+      );
+    });
+
+    testWidgets(
+      'DiViNa comic (CBZ)',
+      // Not part of the bundled web fixture set (see test_fixtures_web.dart) —
+      // native-only asset.
+      skip: kIsWeb,
+      (tester) async {
+        final path = fixturePaths['sample_comic.cbz'];
+        expect(path, isNotNull, reason: 'Fixture sample_comic.cbz missing from asset bundle');
+
+        final pub = await reader.openPublication(path!);
+        expect(
+          pub.conformsToReadiumDivina,
+          isTrue,
+          reason: 'CBZ fixture should conform to the Readium DiViNa profile',
+        );
+        await mountFullyWiredAndSmokeTest(
+          tester,
+          pub,
+          reason: 'Fully-wired DiViNa reader never emitted an initial textLocator',
+        );
+      },
+    );
+  });
 }
+
+/// The same `ReadiumReaderWidget` configuration used in production by
+/// example/lib/widgets/reader.widget.dart — a non-empty `selectionActions` and
+/// all interaction callbacks wired up, rather than the bare
+/// `ReadiumReaderWidget(publication: pub)` the other test groups use.
+ReadiumReaderWidget _fullyWiredReaderWidget(Publication pub) => ReadiumReaderWidget(
+  publication: pub,
+  shouldShowControls: ValueNotifier(true),
+  allowedDefaultActions: const {
+    DefaultSelectionAction.copy,
+    DefaultSelectionAction.share,
+    DefaultSelectionAction.translate,
+  },
+  selectionActions: const [
+    SelectionAction(id: 'highlight', title: 'Highlight'),
+    SelectionAction(id: 'note', title: 'Add Note'),
+  ],
+  onExternalLinkActivated: (_) {},
+  onTextSelected: (_) {},
+  onSelectionAction: (_) {},
+  onDecorationInteraction: (_) {},
+);
 
 /// Drives the timebased playback path end-to-end:
 ///   enable -> play -> wait for [TimebasedState.playing] -> pause

--- a/flutter_readium/example/lib/main.dart
+++ b/flutter_readium/example/lib/main.dart
@@ -47,11 +47,10 @@ Future<void> main() async {
             return bloc;
           },
         ),
-        // BlocProvider(
-        //   create: (final _) => TtsSettingsBloc(),
-        //   lazy: false,
-        // ),
-        BlocProvider(create: (final _) => PlayerControlsBloc()),
+        BlocProvider(create: (final _) => TtsSettingsBloc()),
+        BlocProvider(
+          create: (final ctx) => PlayerControlsBloc(ttsSettingsBloc: ctx.read<TtsSettingsBloc>()),
+        ),
         BlocProvider(create: (final _) => PDFSettingsBloc()),
       ],
       child: MyApp(),

--- a/flutter_readium/example/lib/pages/player.page.dart
+++ b/flutter_readium/example/lib/pages/player.page.dart
@@ -39,6 +39,10 @@ class _PlayerPageState extends State<PlayerPage> with RestorationMixin {
   ) => BlocBuilder<PublicationBloc, PublicationState>(
     builder: (final context, final pubState) {
       final isAudioBook = pubState.publication?.conformsToReadiumAudiobook ?? false;
+      // DiViNa (comics/image-based) publications have no text content — the
+      // "EPUB Settings" sheet (typography/layout/theme) is a poor fit, so
+      // hide the visual settings icon for them.
+      final isDivina = pubState.publication?.conformsToReadiumDivina ?? false;
 
       return PopScope(
         canPop: true,
@@ -67,7 +71,7 @@ class _PlayerPageState extends State<PlayerPage> with RestorationMixin {
                 pubState.error != null ? 'Error' : pubState.publication?.metadata.title ?? 'Unknown',
               ),
             ),
-            actions: _buildActionButtons(isAudioBook),
+            actions: _buildActionButtons(isAudioBook, isDivina),
           ),
           body: Stack(
             children: [
@@ -123,8 +127,8 @@ class _PlayerPageState extends State<PlayerPage> with RestorationMixin {
     },
   );
 
-  List<Widget> _buildActionButtons(final bool isAudioBook) => <Widget>[
-    if (!isAudioBook)
+  List<Widget> _buildActionButtons(final bool isAudioBook, final bool isDivina) => <Widget>[
+    if (!isAudioBook && !isDivina)
       IconButton(
         icon: const Icon(Icons.format_paint),
         onPressed: () {
@@ -144,7 +148,14 @@ class _PlayerPageState extends State<PlayerPage> with RestorationMixin {
     IconButton(
       icon: const Icon(Icons.headphones),
       onPressed: () {
-        if (!isAudioBook) {
+        final publication = context.read<PublicationBloc>().state.publication;
+        // Broader than the `isAudioBook` param above (which only gates the
+        // visual/body layout): also true for Media Overlay / Guided
+        // Navigation EPUBs, which play back through the same audio pipeline
+        // as a plain audiobook and need the same speed/pitch controls.
+        final hasAudioPlayback = publication?.isAudioBook ?? false;
+
+        if (!hasAudioPlayback) {
           context.read<TtsSettingsBloc>().add(LoadAvailableVoices());
         }
 
@@ -152,7 +163,7 @@ class _PlayerPageState extends State<PlayerPage> with RestorationMixin {
           context: context,
           isScrollControlled: true,
           builder: (final context) => PointerInterceptor(
-            child: isAudioBook ? const AudiobookSettingsWidget() : const TtsSettingsWidget(),
+            child: hasAudioPlayback ? const AudioPlaybackSettingsWidget() : const TtsSettingsWidget(),
           ),
         );
       },

--- a/flutter_readium/example/lib/pages/player.page.dart
+++ b/flutter_readium/example/lib/pages/player.page.dart
@@ -67,7 +67,7 @@ class _PlayerPageState extends State<PlayerPage> with RestorationMixin {
                 pubState.error != null ? 'Error' : pubState.publication?.metadata.title ?? 'Unknown',
               ),
             ),
-            actions: _buildActionButtons(),
+            actions: _buildActionButtons(isAudioBook),
           ),
           body: Stack(
             children: [
@@ -123,40 +123,40 @@ class _PlayerPageState extends State<PlayerPage> with RestorationMixin {
     },
   );
 
-  List<Widget> _buildActionButtons() => <Widget>[
-    // IconButton(
-    //   icon: const Icon(Icons.headphones),
-    //   onPressed: () {
-    //     context.read<TtsSettingsBloc>().add(GetTtsVoicesEvent());
+  List<Widget> _buildActionButtons(final bool isAudioBook) => <Widget>[
+    if (!isAudioBook)
+      IconButton(
+        icon: const Icon(Icons.format_paint),
+        onPressed: () {
+          final publication = context.read<PublicationBloc>().state.publication;
+          final isPDF = publication?.conformsToReadiumPDF ?? false;
 
-    //     final pubLang =
-    //         context.read<PublicationBloc>().state.publication?.metadata.language ?? ['en'];
-
-    //     showModalBottomSheet(
-    //       context: context,
-    //       isScrollControlled: true,
-    //       builder: (final context) => TtsSettingsWidget(
-    //         pubLang: pubLang,
-    //       ),
-    //     );
-    //   },
-    //   tooltip: 'Open tts settings',
-    // ),
+          showModalBottomSheet(
+            context: context,
+            isScrollControlled: true,
+            builder: (final context) => PointerInterceptor(
+              child: isPDF ? const PDFSettingsWidget() : const TextSettingsWidget(),
+            ),
+          );
+        },
+        tooltip: 'Open visual reader settings',
+      ),
     IconButton(
-      icon: const Icon(Icons.format_paint),
+      icon: const Icon(Icons.headphones),
       onPressed: () {
-        final publication = context.read<PublicationBloc>().state.publication;
-        final isPDF = publication?.conformsToReadiumPDF ?? false;
+        if (!isAudioBook) {
+          context.read<TtsSettingsBloc>().add(LoadAvailableVoices());
+        }
 
         showModalBottomSheet(
           context: context,
           isScrollControlled: true,
           builder: (final context) => PointerInterceptor(
-            child: isPDF ? const PDFSettingsWidget() : const TextSettingsWidget(),
+            child: isAudioBook ? const AudiobookSettingsWidget() : const TtsSettingsWidget(),
           ),
         );
       },
-      tooltip: 'Open reader settings',
+      tooltip: 'Open audio/playback settings',
     ),
     IconButton(
       icon: const Icon(Icons.search),

--- a/flutter_readium/example/lib/state/player_controls_bloc.dart
+++ b/flutter_readium/example/lib/state/player_controls_bloc.dart
@@ -99,6 +99,12 @@ class ChangeAudioSeekInterval extends PlayerControlsEvent {
 }
 
 @immutable
+class ChangeAudioPitch extends PlayerControlsEvent {
+  ChangeAudioPitch(this.value);
+  final double value;
+}
+
+@immutable
 class UpdateCurrentTocHref extends PlayerControlsEvent {
   UpdateCurrentTocHref(this.tocHref);
 
@@ -123,6 +129,7 @@ class PlayerControlsState {
     required this.audioControlPanelTimebase,
     this.audioSpeed = 1.5,
     this.audioSeekInterval = 10.0,
+    this.audioPitch = 1.0,
     this.narrationSyncEnabled,
     this.currentTocHref,
   });
@@ -133,6 +140,7 @@ class PlayerControlsState {
   final ControlPanelTimebase audioControlPanelTimebase;
   final double audioSpeed;
   final double audioSeekInterval;
+  final double audioPitch;
   final bool? narrationSyncEnabled;
   final String? currentTocHref;
 
@@ -143,6 +151,7 @@ class PlayerControlsState {
     ControlPanelTimebase? audioControlPanelTimebase,
     double? audioSpeed,
     double? audioSeekInterval,
+    double? audioPitch,
     bool? narrationSyncEnabled,
     String? currentTocHref,
   }) => PlayerControlsState(
@@ -152,6 +161,7 @@ class PlayerControlsState {
     audioControlPanelTimebase: audioControlPanelTimebase ?? this.audioControlPanelTimebase,
     audioSpeed: audioSpeed ?? this.audioSpeed,
     audioSeekInterval: audioSeekInterval ?? this.audioSeekInterval,
+    audioPitch: audioPitch ?? this.audioPitch,
     narrationSyncEnabled: narrationSyncEnabled != null ? narrationSyncEnabled : this.narrationSyncEnabled,
     currentTocHref: currentTocHref ?? this.currentTocHref,
   );
@@ -185,6 +195,7 @@ class PlayerControlsState {
     audioControlPanelTimebase: audioControlPanelTimebase,
     audioSpeed: audioSpeed,
     audioSeekInterval: audioSeekInterval,
+    audioPitch: audioPitch,
     currentTocHref: null,
   );
 }
@@ -424,10 +435,19 @@ class PlayerControlsBloc extends Bloc<PlayerControlsEvent, PlayerControlsState> 
         await instance.audioSetPreferences(_buildAudioPreferences(state.audioControlPanelTimebase));
       }
     });
+
+    on<ChangeAudioPitch>((event, emit) async {
+      emit(state.copyWith(audioPitch: event.value));
+
+      if (state.audioEnabled) {
+        await instance.audioSetPreferences(_buildAudioPreferences(state.audioControlPanelTimebase));
+      }
+    });
   }
 
   AudioPreferences _buildAudioPreferences(ControlPanelTimebase timebase) => AudioPreferences(
     speed: state.audioSpeed,
+    pitch: state.audioPitch,
     seekInterval: state.audioSeekInterval,
     continuousSeeking: true,
     controlPanelTimebase: timebase,

--- a/flutter_readium/example/lib/state/player_controls_bloc.dart
+++ b/flutter_readium/example/lib/state/player_controls_bloc.dart
@@ -5,9 +5,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:collection/collection.dart';
 
 import 'package:flutter_readium/flutter_readium.dart';
+
+import 'tts_settings_bloc.dart';
 
 final _log = Logger('PlayerControlsBloc');
 
@@ -86,7 +87,16 @@ class SeekRelative extends PlayerControlsEvent {
 }
 
 @immutable
-class GetAvailableVoices extends PlayerControlsEvent {}
+class ChangeAudioSpeed extends PlayerControlsEvent {
+  ChangeAudioSpeed(this.value);
+  final double value;
+}
+
+@immutable
+class ChangeAudioSeekInterval extends PlayerControlsEvent {
+  ChangeAudioSeekInterval(this.value);
+  final double value;
+}
 
 @immutable
 class UpdateCurrentTocHref extends PlayerControlsEvent {
@@ -111,6 +121,8 @@ class PlayerControlsState {
     required this.ttsEnabled,
     required this.audioEnabled,
     required this.audioControlPanelTimebase,
+    this.audioSpeed = 1.5,
+    this.audioSeekInterval = 10.0,
     this.narrationSyncEnabled,
     this.currentTocHref,
   });
@@ -119,6 +131,8 @@ class PlayerControlsState {
   final bool ttsEnabled;
   final bool audioEnabled;
   final ControlPanelTimebase audioControlPanelTimebase;
+  final double audioSpeed;
+  final double audioSeekInterval;
   final bool? narrationSyncEnabled;
   final String? currentTocHref;
 
@@ -127,6 +141,8 @@ class PlayerControlsState {
     bool? ttsEnabled,
     bool? audioEnabled,
     ControlPanelTimebase? audioControlPanelTimebase,
+    double? audioSpeed,
+    double? audioSeekInterval,
     bool? narrationSyncEnabled,
     String? currentTocHref,
   }) => PlayerControlsState(
@@ -134,6 +150,8 @@ class PlayerControlsState {
     ttsEnabled: ttsEnabled != null ? ttsEnabled : this.ttsEnabled,
     audioEnabled: audioEnabled != null ? audioEnabled : this.audioEnabled,
     audioControlPanelTimebase: audioControlPanelTimebase ?? this.audioControlPanelTimebase,
+    audioSpeed: audioSpeed ?? this.audioSpeed,
+    audioSeekInterval: audioSeekInterval ?? this.audioSeekInterval,
     narrationSyncEnabled: narrationSyncEnabled != null ? narrationSyncEnabled : this.narrationSyncEnabled,
     currentTocHref: currentTocHref ?? this.currentTocHref,
   );
@@ -165,6 +183,8 @@ class PlayerControlsState {
     ttsEnabled: false,
     audioEnabled: false,
     audioControlPanelTimebase: audioControlPanelTimebase,
+    audioSpeed: audioSpeed,
+    audioSeekInterval: audioSeekInterval,
     currentTocHref: null,
   );
 }
@@ -175,13 +195,14 @@ class ToggleAudioControlPanelTimebase extends PlayerControlsEvent {}
 class PlayerControlsBloc extends Bloc<PlayerControlsEvent, PlayerControlsState> {
   List<StreamSubscription> subscriptions = [];
   Locator? currentLocator;
+  final TtsSettingsBloc ttsSettingsBloc;
 
   /// Broadcasts the current resource [Locator] regardless of media type, retaining
   /// the latest value so late subscribers (e.g. a slider rebuilt by the parent
   /// `BlocBuilder`) immediately receive the current progression.
   final BehaviorSubject<Locator> _currentLocatorSubject = BehaviorSubject<Locator>();
 
-  PlayerControlsBloc()
+  PlayerControlsBloc({required this.ttsSettingsBloc})
     : super(
         PlayerControlsState(
           playing: false,
@@ -269,7 +290,12 @@ class PlayerControlsBloc extends Bloc<PlayerControlsEvent, PlayerControlsState> 
 
     on<PlayTTS>((final event, final emit) async {
       if (!state.ttsEnabled) {
-        await instance.ttsEnable(TTSPreferences(speed: 1.2));
+        await instance.ttsEnable(ttsSettingsBloc.buildPreferences());
+        // TTSPreferences.voices is only honored by Android — push each
+        // per-language selection again via ttsSetVoice so iOS/Web pick it up.
+        for (final entry in ttsSettingsBloc.state.voicesByLanguage.entries) {
+          await instance.ttsSetVoice(entry.value, entry.key);
+        }
         await instance.play(event.fromLocator);
         emit(
           state.toggleTTSEnabled(true, event.fromLocator?.locations?.tocHref),
@@ -371,31 +397,6 @@ class PlayerControlsBloc extends Bloc<PlayerControlsEvent, PlayerControlsState> 
       emit(state.copyWith(narrationSyncEnabled: event.enabled));
     });
 
-    on<GetAvailableVoices>((final event, final emit) async {
-      final voices = await instance.ttsGetAvailableVoices();
-
-      // Sort by identifer
-      voices.sortBy((v) => v.identifier);
-
-      for (final i in voices.groupListsBy((v) => v.language).entries) {
-        _log.info('Language: ${i.key}');
-        _log.info('  Available voices:');
-        for (final v in i.value) {
-          _log.info(
-            '    - ${v.identifier},name=${v.name},quality=${v.quality?.name},gender=${v.gender.name},active=${v.active},networkRequired=${v.networkRequired}',
-          );
-        }
-      }
-
-      final dkVoices = voices.where((v) => v.language == "da-DK").toList();
-
-      // TODO: Demo: change to first voice matching "da-DK" language.
-      final daVoice = dkVoices.lastOrNull;
-      if (daVoice != null) {
-        await instance.ttsSetVoice(daVoice.identifier, daVoice.language);
-      }
-    });
-
     on<ToggleAudioControlPanelTimebase>((event, emit) async {
       final nextTimebase = state.audioControlPanelTimebase == ControlPanelTimebase.chapter
           ? ControlPanelTimebase.wholeBook
@@ -407,11 +408,27 @@ class PlayerControlsBloc extends Bloc<PlayerControlsEvent, PlayerControlsState> 
         await instance.audioSetPreferences(_buildAudioPreferences(nextTimebase));
       }
     });
+
+    on<ChangeAudioSpeed>((event, emit) async {
+      emit(state.copyWith(audioSpeed: event.value));
+
+      if (state.audioEnabled) {
+        await instance.audioSetPreferences(_buildAudioPreferences(state.audioControlPanelTimebase));
+      }
+    });
+
+    on<ChangeAudioSeekInterval>((event, emit) async {
+      emit(state.copyWith(audioSeekInterval: event.value));
+
+      if (state.audioEnabled) {
+        await instance.audioSetPreferences(_buildAudioPreferences(state.audioControlPanelTimebase));
+      }
+    });
   }
 
   AudioPreferences _buildAudioPreferences(ControlPanelTimebase timebase) => AudioPreferences(
-    speed: 1.5,
-    seekInterval: 10,
+    speed: state.audioSpeed,
+    seekInterval: state.audioSeekInterval,
     continuousSeeking: true,
     controlPanelTimebase: timebase,
   );

--- a/flutter_readium/example/lib/state/tts_settings_bloc.dart
+++ b/flutter_readium/example/lib/state/tts_settings_bloc.dart
@@ -1,123 +1,131 @@
-// import 'package:flutter_bloc/flutter_bloc.dart';
-// import 'package:flutter_readium/flutter_readium.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_readium/flutter_readium.dart';
+import 'package:logging/logging.dart';
 
-// abstract class TtsSettingsEvent {}
+final _log = Logger('TtsSettingsBloc');
 
-// class GetTtsVoicesEvent extends TtsSettingsEvent {
-//   GetTtsVoicesEvent({this.fallbackLang});
-//   final List<String>? fallbackLang;
-// }
+abstract class TtsSettingsEvent {}
 
-// class SetTtsVoiceEvent extends TtsSettingsEvent {
-//   SetTtsVoiceEvent(this.selectedVoice);
-//   final ReadiumTtsVoice selectedVoice;
-// }
+@immutable
+class LoadAvailableVoices extends TtsSettingsEvent {}
 
-// class SetTtsHighlightModeEvent extends TtsSettingsEvent {
-//   SetTtsHighlightModeEvent(this.highlightMode);
-//   final ReadiumHighlightMode highlightMode;
-// }
+@immutable
+class ChangeSpeed extends TtsSettingsEvent {
+  ChangeSpeed(this.value);
+  final double value;
+}
 
-// class ToggleTtsHighlightModeEvent extends TtsSettingsEvent {}
+@immutable
+class ChangePitch extends TtsSettingsEvent {
+  ChangePitch(this.value);
+  final double value;
+}
 
-// class SetTtsSpeakPhysicalPageIndexEvent extends TtsSettingsEvent {
-//   SetTtsSpeakPhysicalPageIndexEvent(this.speak);
-//   final bool speak;
-// }
+@immutable
+class ChangeVoiceForLanguage extends TtsSettingsEvent {
+  ChangeVoiceForLanguage(this.language, this.voiceIdentifier);
+  final String? language;
+  final String voiceIdentifier;
+}
 
-// class TtsSettingsState {
-//   TtsSettingsState({
-//     this.voices,
-//     this.loaded,
-//     this.preferredVoices,
-//     this.highlightMode,
-//     this.ttsSpeakPhysicalPageIndex,
-//   });
-//   final List<ReadiumTtsVoice>? voices;
-//   final bool? loaded;
-//   final List<ReadiumTtsVoice>? preferredVoices;
-//   final ReadiumHighlightMode? highlightMode;
-//   final bool? ttsSpeakPhysicalPageIndex;
+@immutable
+class TtsSettingsState {
+  const TtsSettingsState({
+    this.speed = 1.0,
+    this.pitch = 1.0,
+    this.voicesByLanguage = const {},
+    this.availableVoices = const [],
+    this.voicesLoaded = false,
+  });
 
-//   TtsSettingsState copyWith({
-//     final List<ReadiumTtsVoice>? voices,
-//     final bool? loaded,
-//     final List<ReadiumTtsVoice>? preferredVoices,
-//     final ReadiumHighlightMode? highlightMode,
-//     final bool? ttsSpeakPhysicalPageIndex,
-//   }) =>
-//       TtsSettingsState(
-//         voices: voices ?? this.voices,
-//         loaded: loaded ?? this.loaded,
-//         preferredVoices: preferredVoices ?? this.preferredVoices,
-//         highlightMode: highlightMode ?? this.highlightMode,
-//         ttsSpeakPhysicalPageIndex: ttsSpeakPhysicalPageIndex ?? this.ttsSpeakPhysicalPageIndex,
-//       );
+  /// Speech rate. 1.0 is normal speed.
+  final double speed;
 
-//   TtsSettingsState updateVoices(final List<ReadiumTtsVoice> voices) => copyWith(
-//         voices: voices,
-//         loaded: true,
-//       );
+  /// Speech pitch. 1.0 is normal pitch.
+  final double pitch;
 
-//   TtsSettingsState updatePreferredVoices(final ReadiumTtsVoice selectedVoice) {
-//     final preferredVoicesList = preferredVoices ?? [];
-//     final updatedVoices = preferredVoicesList
-//         .where((final voice) => voice.langCode != selectedVoice.langCode)
-//         .toList()
-//       ..add(selectedVoice);
+  /// Selected voice identifier per publication language. A `null` key is used
+  /// when the publication declares no language and a single default voice
+  /// picker is shown instead.
+  final Map<String?, String> voicesByLanguage;
+  final List<ReaderTTSVoice> availableVoices;
+  final bool voicesLoaded;
 
-//     FlutterReadium().updateCurrentTtsVoicesReadium(updatedVoices);
+  TtsSettingsState copyWith({
+    double? speed,
+    double? pitch,
+    Map<String?, String>? voicesByLanguage,
+    List<ReaderTTSVoice>? availableVoices,
+    bool? voicesLoaded,
+  }) => TtsSettingsState(
+    speed: speed ?? this.speed,
+    pitch: pitch ?? this.pitch,
+    voicesByLanguage: voicesByLanguage ?? this.voicesByLanguage,
+    availableVoices: availableVoices ?? this.availableVoices,
+    voicesLoaded: voicesLoaded ?? this.voicesLoaded,
+  );
+}
 
-//     return copyWith(preferredVoices: updatedVoices);
-//   }
+class TtsSettingsBloc extends Bloc<TtsSettingsEvent, TtsSettingsState> {
+  TtsSettingsBloc() : super(const TtsSettingsState()) {
+    on<LoadAvailableVoices>((final event, final emit) async {
+      final voices = await instance.ttsGetAvailableVoices();
 
-//   TtsSettingsState setHighlightMode(final ReadiumHighlightMode highlightMode) {
-//     FlutterReadium().setHighlightMode(highlightMode);
-//     return copyWith(highlightMode: highlightMode);
-//   }
+      // Sort by identifier.
+      voices.sortBy((v) => v.identifier);
 
-//   TtsSettingsState setTtsSpeakPhysicalPageIndex(final bool speak) {
-//     FlutterReadium().setTtsSpeakPhysicalPageIndex(speak: speak);
-//     return copyWith(ttsSpeakPhysicalPageIndex: speak);
-//   }
-// }
+      for (final i in voices.groupListsBy((v) => v.language).entries) {
+        _log.info('Language: ${i.key}');
+        _log.info('  Available voices:');
+        for (final v in i.value) {
+          _log.info(
+            '    - ${v.identifier},name=${v.name},quality=${v.quality?.name},gender=${v.gender.name},active=${v.active},networkRequired=${v.networkRequired}',
+          );
+        }
+      }
 
-// class TtsSettingsBloc extends Bloc<TtsSettingsEvent, TtsSettingsState> {
-//   TtsSettingsBloc()
-//       : super(
-//           TtsSettingsState(
-//             voices: [],
-//             loaded: false,
-//             preferredVoices: [],
-//             highlightMode: ReadiumHighlightMode.paragraph, // to reflect default in ReadiumState
-//             ttsSpeakPhysicalPageIndex: false,
-//           ),
-//         ) {
-//     on<GetTtsVoicesEvent>((final event, final emit) async {
-//       final voices = await instance.getTtsVoices(fallbackLang: event.fallbackLang);
-//       emit(state.updateVoices(voices));
-//     });
+      emit(state.copyWith(availableVoices: voices, voicesLoaded: true));
+    });
 
-//     on<SetTtsVoiceEvent>((final event, final emit) async {
-//       await instance.setTtsVoice(event.selectedVoice);
-//       emit(state.updatePreferredVoices(event.selectedVoice));
-//     });
+    on<ChangeSpeed>((final event, final emit) async {
+      emit(state.copyWith(speed: event.value));
+      await _applyPreferences();
+    });
 
-//     on<SetTtsHighlightModeEvent>((final event, final emit) async {
-//       emit(state.setHighlightMode(event.highlightMode));
-//     });
+    on<ChangePitch>((final event, final emit) async {
+      emit(state.copyWith(pitch: event.value));
+      await _applyPreferences();
+    });
 
-//     on<ToggleTtsHighlightModeEvent>((final event, final emit) async {
-//       final newHighlightMode = state.highlightMode == ReadiumHighlightMode.word
-//           ? ReadiumHighlightMode.paragraph
-//           : ReadiumHighlightMode.word;
-//       emit(state.setHighlightMode(newHighlightMode));
-//     });
+    on<ChangeVoiceForLanguage>((final event, final emit) async {
+      final voicesByLanguage = Map<String?, String>.of(state.voicesByLanguage)
+        ..[event.language] = event.voiceIdentifier;
+      emit(state.copyWith(voicesByLanguage: voicesByLanguage));
+      await instance.ttsSetVoice(event.voiceIdentifier, event.language).catchError((e) {
+        _log.warning('ttsSetVoice failed (TTS likely not active yet): $e');
+      });
+    });
+  }
 
-//     on<SetTtsSpeakPhysicalPageIndexEvent>((final event, final emit) async {
-//       emit(state.setTtsSpeakPhysicalPageIndex(event.speak));
-//     });
-//   }
+  final FlutterReadium instance = FlutterReadium();
 
-//   final FlutterReadium instance = FlutterReadium();
-// }
+  Future<void> _applyPreferences() async {
+    await instance.ttsSetPreferences(buildPreferences()).catchError((e) {
+      _log.warning('ttsSetPreferences failed (TTS likely not active yet): $e');
+    });
+  }
+
+  /// Builds the [TTSPreferences] to pass to [FlutterReadium.ttsEnable]. The
+  /// `null`-language fallback entry in [TtsSettingsState.voicesByLanguage] is
+  /// dropped here, since [TTSPreferences.voices] is keyed by language only.
+  TTSPreferences buildPreferences() => TTSPreferences(
+    speed: state.speed,
+    pitch: state.pitch,
+    voices: {
+      for (final entry in state.voicesByLanguage.entries)
+        if (entry.key != null) entry.key!: entry.value,
+    },
+  );
+}

--- a/flutter_readium/example/lib/widgets/audio_playback_settings.widget.dart
+++ b/flutter_readium/example/lib/widgets/audio_playback_settings.widget.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../state/player_controls_bloc.dart';
+import '../state/publication_bloc.dart';
+import 'index.dart';
+
+/// Playback settings for timebased audio: pure audiobooks as well as
+/// Media Overlay / Guided Navigation EPUBs (pre-recorded narration synced to
+/// text). The latter additionally get a [HighlightSettingsSection] since,
+/// unlike a plain audiobook, there is visible text to highlight while it plays.
+class AudioPlaybackSettingsWidget extends StatelessWidget {
+  const AudioPlaybackSettingsWidget({super.key});
+
+  @override
+  Widget build(final BuildContext context) {
+    final playerControlsBloc = context.watch<PlayerControlsBloc>();
+    final state = playerControlsBloc.state;
+    final publication = context.watch<PublicationBloc>().state.publication;
+    // A pure audiobook has no visible text, so there's nothing to highlight —
+    // only Media Overlay / Guided Navigation publications get the section.
+    final showHighlightSection = !(publication?.conformsToReadiumAudiobook ?? true);
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.5,
+      minChildSize: 0.25,
+      maxChildSize: 0.75,
+      expand: false,
+      builder: (context, scrollController) => SingleChildScrollView(
+        controller: scrollController,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(20.0),
+              child: Semantics(
+                header: true,
+                child: const Align(
+                  alignment: Alignment.center,
+                  child: Text('Playback Settings', style: TextStyle(fontSize: 25)),
+                ),
+              ),
+            ),
+            const Divider(),
+            ListItemWidget(
+              label: 'Speed: ${state.audioSpeed.toStringAsFixed(2)}x',
+              child: Slider(
+                key: const ValueKey('audiobook_speed_slider'),
+                value: state.audioSpeed,
+                min: 0.5,
+                max: 3.0,
+                divisions: 10,
+                label: state.audioSpeed.toStringAsFixed(2),
+                onChanged: (value) => playerControlsBloc.add(ChangeAudioSpeed(value)),
+              ),
+            ),
+            // Pitch is plumbed through Dart/native on all three platforms (iOS,
+            // Android, Web) but none of their audio navigators actually apply
+            // it to playback — only TTS pitch (a separate code path) works.
+            // Surface that honestly rather than let the slider silently no-op.
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Text(
+                'Pitch currently has no effect on audiobooks or MediaOverlay playback — '
+                'not supported by Readium toolkit audio engines.',
+                style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+              ),
+            ),
+            ListItemWidget(
+              label: 'Pitch: ${state.audioPitch.toStringAsFixed(2)}',
+              child: Slider(
+                key: const ValueKey('audiobook_pitch_slider'),
+                value: state.audioPitch,
+                min: 0.5,
+                max: 2.0,
+                divisions: 6,
+                label: state.audioPitch.toStringAsFixed(2),
+                onChanged: (value) => playerControlsBloc.add(ChangeAudioPitch(value)),
+              ),
+            ),
+            ListItemWidget(
+              label: 'Seek Interval: ${state.audioSeekInterval.toStringAsFixed(0)}s',
+              child: Slider(
+                key: const ValueKey('audiobook_seek_interval_slider'),
+                value: state.audioSeekInterval,
+                min: 5.0,
+                max: 60.0,
+                divisions: 11,
+                label: state.audioSeekInterval.toStringAsFixed(0),
+                onChanged: (value) => playerControlsBloc.add(ChangeAudioSeekInterval(value)),
+              ),
+            ),
+            if (showHighlightSection) ...[
+              const Divider(),
+              const HighlightSettingsSection(showRange: false),
+            ],
+            const Divider(),
+            TextButton(
+              key: const ValueKey('audiobook_settings_close_button'),
+              onPressed: () => Navigator.of(context).pop(),
+              style: ButtonStyle(
+                padding: WidgetStateProperty.all<EdgeInsets>(const EdgeInsets.symmetric(vertical: 16.0)),
+                shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                spacing: 8.0,
+                children: [
+                  Icon(Icons.close, size: 20),
+                  Text('Close', style: TextStyle(fontSize: 20)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_readium/example/lib/widgets/highlight_settings.widget.dart
+++ b/flutter_readium/example/lib/widgets/highlight_settings.widget.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_readium/flutter_readium.dart';
+
+import '../extensions/text_settings_theme.dart';
+import '../state/text_settings_bloc.dart';
+import 'index.dart';
+
+/// The decoration color + style pickers shared by the TTS and audio-playback
+/// settings sheets. TTS has two independently-styled decorations (Utterance,
+/// the currently-spoken chunk, and Range, the currently-spoken word); Media
+/// Overlay / Guided Navigation playback only ever highlights one level (its
+/// native `requestsHighlightAt` callback never supplies a word locator), so
+/// [showRange] hides the second picker in that case.
+class HighlightSettingsSection extends StatelessWidget {
+  const HighlightSettingsSection({required this.showRange, super.key});
+
+  final bool showRange;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const SectionHeader(title: 'Highlight'),
+        ListItemWidget(
+          label: 'Color',
+          child: ThemeSelectorWidget(themes: highlights, isHighlight: true),
+        ),
+        ListItemWidget(
+          label: showRange ? 'Utterance' : 'Style',
+          child: _DecorationStyleSelector(
+            buttonKey: const ValueKey('utterance_style_selector'),
+            selector: (state) => state.utteranceStyle,
+            onChanged: (value) => context.read<TextSettingsBloc>().add(ChangeUtteranceStyle(value)),
+          ),
+        ),
+        if (showRange)
+          ListItemWidget(
+            label: 'Range',
+            child: _DecorationStyleSelector(
+              buttonKey: const ValueKey('range_style_selector'),
+              selector: (state) => state.rangeStyle,
+              onChanged: (value) => context.read<TextSettingsBloc>().add(ChangeRangeStyle(value)),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _DecorationStyleSelector extends StatelessWidget {
+  const _DecorationStyleSelector({required this.buttonKey, required this.selector, required this.onChanged});
+
+  final Key buttonKey;
+  final DecorationStyle? Function(TextSettingsState state) selector;
+  final void Function(DecorationStyle? value) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<TextSettingsBloc, TextSettingsState, DecorationStyle?>(
+      selector: selector,
+      builder: (context, style) => SegmentedButton<DecorationStyle?>(
+        key: buttonKey,
+        emptySelectionAllowed: true,
+        segments: const [
+          ButtonSegment(value: null, label: Text('Off')),
+          ButtonSegment(value: DecorationStyle.highlight, label: Text('Fill')),
+          ButtonSegment(value: DecorationStyle.underline, label: Text('Line')),
+          ButtonSegment(value: DecorationStyle.spotlight, label: Text('Spot')),
+        ],
+        selected: {style},
+        onSelectionChanged: (values) => onChanged(values.isEmpty ? null : values.first),
+      ),
+    );
+  }
+}

--- a/flutter_readium/example/lib/widgets/index.dart
+++ b/flutter_readium/example/lib/widgets/index.dart
@@ -1,3 +1,4 @@
+export 'audiobook_settings.widget.dart';
 export 'list_item.widget.dart';
 export 'pdf_settings.widget.dart';
 export 'player_controls.widget.dart';

--- a/flutter_readium/example/lib/widgets/index.dart
+++ b/flutter_readium/example/lib/widgets/index.dart
@@ -1,4 +1,5 @@
-export 'audiobook_settings.widget.dart';
+export 'audio_playback_settings.widget.dart';
+export 'highlight_settings.widget.dart';
 export 'list_item.widget.dart';
 export 'pdf_settings.widget.dart';
 export 'player_controls.widget.dart';

--- a/flutter_readium/example/lib/widgets/list_item.widget.dart
+++ b/flutter_readium/example/lib/widgets/list_item.widget.dart
@@ -41,3 +41,20 @@ class ListItemWidget extends StatelessWidget {
           ),
   );
 }
+
+class SectionHeader extends StatelessWidget {
+  const SectionHeader({required this.title, super.key});
+  final String title;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+    child: Align(
+      alignment: Alignment.centerLeft,
+      child: Text(
+        title,
+        style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.primary),
+      ),
+    ),
+  );
+}

--- a/flutter_readium/example/lib/widgets/player_controls.widget.dart
+++ b/flutter_readium/example/lib/widgets/player_controls.widget.dart
@@ -112,13 +112,6 @@ class PlayerControls extends StatelessWidget {
                     ToggleAudioControlPanelTimebase(),
                   ),
                 ),
-              IconButton(
-                icon: const Icon(Icons.settings_voice),
-                onPressed: () => context.read<PlayerControlsBloc>().add(
-                  GetAvailableVoices(),
-                ),
-                tooltip: 'Change voice',
-              ),
             ],
           ),
         ],

--- a/flutter_readium/example/lib/widgets/text_settings.widget.dart
+++ b/flutter_readium/example/lib/widgets/text_settings.widget.dart
@@ -10,8 +10,17 @@ import 'index.dart';
 
 const List<String> _fontFamilies = ['Original', 'serif', 'sans-serif', 'monospace'];
 
-class TextSettingsWidget extends StatelessWidget {
+enum _Section { text, layout, theme }
+
+class TextSettingsWidget extends StatefulWidget {
   const TextSettingsWidget({super.key});
+
+  @override
+  State<TextSettingsWidget> createState() => _TextSettingsWidgetState();
+}
+
+class _TextSettingsWidgetState extends State<TextSettingsWidget> {
+  _Section _section = _Section.text;
 
   @override
   Widget build(final BuildContext context) {
@@ -25,9 +34,9 @@ class TextSettingsWidget extends StatelessWidget {
     final scrollToggleDisabled = kIsWeb && !(publication?.conformsToReadiumEbook ?? false);
 
     return DraggableScrollableSheet(
-      initialChildSize: 0.8,
+      initialChildSize: 0.75,
       minChildSize: 0.4,
-      maxChildSize: 0.8,
+      maxChildSize: 0.75,
       expand: false,
       builder: (context, scrollController) => SingleChildScrollView(
         controller: scrollController,
@@ -44,202 +53,270 @@ class TextSettingsWidget extends StatelessWidget {
               ),
             ),
             const Divider(),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: SegmentedButton<_Section>(
+                key: const ValueKey('text_settings_section_selector'),
+                segments: const [
+                  ButtonSegment(value: _Section.text, label: Text('Text')),
+                  ButtonSegment(value: _Section.layout, label: Text('Layout')),
+                  ButtonSegment(value: _Section.theme, label: Text('Theme')),
+                ],
+                selected: {_section},
+                onSelectionChanged: (values) => setState(() => _section = values.first),
+              ),
+            ),
+            const Divider(),
+            switch (_section) {
+              _Section.text => _TextSection(textSettingsBloc: textSettingsBloc, state: state),
+              _Section.layout => _LayoutSection(
+                textSettingsBloc: textSettingsBloc,
+                state: state,
+                scrollToggleDisabled: scrollToggleDisabled,
+              ),
+              _Section.theme => _ThemeSection(textSettingsBloc: textSettingsBloc, state: state),
+            },
+            const Divider(),
+            TextButton(
+              key: const ValueKey('text_settings_close_button'),
+              onPressed: () => Navigator.of(context).pop(),
+              style: ButtonStyle(
+                padding: WidgetStateProperty.all<EdgeInsets>(const EdgeInsets.symmetric(vertical: 16.0)),
+                shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                spacing: 8.0,
+                children: [
+                  Icon(Icons.close, size: 20),
+                  Text('Close', style: TextStyle(fontSize: 20)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
-            // --- Basic Typography ---
-            _SectionHeader(title: 'Typography'),
+class _TextSection extends StatelessWidget {
+  const _TextSection({required this.textSettingsBloc, required this.state});
+
+  final TextSettingsBloc textSettingsBloc;
+  final TextSettingsState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListItemWidget(
+          label: 'Font Size',
+          child: Slider(
+            key: const ValueKey('font_size_slider'),
+            value: state.fontSize.toDouble(),
+            min: 70.0,
+            max: 200.0,
+            divisions: 13,
+            label: state.fontSize.toString(),
+            onChanged: (value) {
+              textSettingsBloc.add(ChangeFontSize(value.toInt()));
+            },
+          ),
+        ),
+        ListItemWidget(
+          label: 'Font Family',
+          child: DropdownMenu<String>(
+            key: const ValueKey('font_family_selector'),
+            initialSelection: state.fontFamily,
+            dropdownMenuEntries: _fontFamilies.map((f) => DropdownMenuEntry(value: f, label: f)).toList(),
+            onSelected: (value) {
+              if (value != null) textSettingsBloc.add(ChangeFontFamily(value));
+            },
+          ),
+        ),
+        ListItemWidget(
+          label: 'Text Align',
+          child: SegmentedButton<TextAlign>(
+            key: const ValueKey('text_align_selector'),
+            emptySelectionAllowed: true,
+            segments: const [
+              ButtonSegment(value: TextAlign.start, icon: Icon(Icons.format_align_left), tooltip: 'Start'),
+              ButtonSegment(value: TextAlign.right, icon: Icon(Icons.format_align_right), tooltip: 'Right'),
+              ButtonSegment(value: TextAlign.justify, icon: Icon(Icons.format_align_justify), tooltip: 'Justify'),
+            ],
+            selected: state.textAlign != null ? {state.textAlign!} : {},
+            onSelectionChanged: (values) {
+              textSettingsBloc.add(ChangeTextAlign(values.isEmpty ? null : values.first));
+            },
+          ),
+        ),
+        const Divider(),
+        _CollapsibleSection(
+          title: 'Advanced Typography',
+          initiallyExpanded: false,
+          children: [
             ListItemWidget(
-              label: 'Font Size',
+              label: 'Font Weight',
               child: Slider(
-                key: const ValueKey('font_size_slider'),
-                value: state.fontSize.toDouble(),
-                min: 70.0,
-                max: 200.0,
-                divisions: 13,
-                label: state.fontSize.toString(),
+                key: const ValueKey('font_weight_slider'),
+                value: state.fontWeight,
+                min: kIsWeb ? 1.0 : 0.5,
+                max: kIsWeb ? 9.0 : 2.0,
+                divisions: kIsWeb ? 8 : 6,
+                label: kIsWeb ? (state.fontWeight * 100).toStringAsFixed(0) : state.fontWeight.toStringAsFixed(1),
                 onChanged: (value) {
-                  textSettingsBloc.add(ChangeFontSize(value.toInt()));
+                  textSettingsBloc.add(ChangeFontWeight(value));
                 },
               ),
             ),
             ListItemWidget(
-              label: 'Font Family',
-              child: DropdownMenu<String>(
-                key: const ValueKey('font_family_selector'),
-                initialSelection: state.fontFamily,
-                dropdownMenuEntries: _fontFamilies.map((f) => DropdownMenuEntry(value: f, label: f)).toList(),
-                onSelected: (value) {
-                  if (value != null) textSettingsBloc.add(ChangeFontFamily(value));
+              label: 'Letter Spacing',
+              child: Slider(
+                key: const ValueKey('letter_spacing_slider'),
+                value: state.letterSpacing ?? 0.0,
+                min: -0.1,
+                max: 0.5,
+                divisions: 6,
+                label: (state.letterSpacing ?? 0.0).toStringAsFixed(2),
+                onChanged: (value) {
+                  textSettingsBloc.add(ChangeLetterSpacing(value));
                 },
               ),
             ),
             ListItemWidget(
-              label: 'Text Align',
-              child: SegmentedButton<TextAlign>(
-                key: const ValueKey('text_align_selector'),
-                emptySelectionAllowed: true,
-                segments: const [
-                  ButtonSegment(value: TextAlign.start, icon: Icon(Icons.format_align_left), tooltip: 'Start'),
-                  ButtonSegment(value: TextAlign.right, icon: Icon(Icons.format_align_right), tooltip: 'Right'),
-                  ButtonSegment(value: TextAlign.justify, icon: Icon(Icons.format_align_justify), tooltip: 'Justify'),
-                ],
-                selected: state.textAlign != null ? {state.textAlign!} : {},
-                onSelectionChanged: (values) {
-                  textSettingsBloc.add(ChangeTextAlign(values.isEmpty ? null : values.first));
+              label: 'Word Spacing',
+              child: Slider(
+                key: const ValueKey('word_spacing_slider'),
+                value: state.wordSpacing ?? 0.0,
+                min: 0.0,
+                max: 1.0,
+                divisions: 5,
+                label: (state.wordSpacing ?? 0.0).toStringAsFixed(2),
+                onChanged: (value) {
+                  textSettingsBloc.add(ChangeWordSpacing(value));
                 },
               ),
             ),
-            const Divider(),
+            ListItemWidget(
+              label: 'Line Height',
+              child: Slider(
+                key: const ValueKey('line_height_slider'),
+                value: state.lineHeight ?? 1.2,
+                min: 1.0,
+                max: 3.0,
+                divisions: 8,
+                label: (state.lineHeight ?? 1.2).toStringAsFixed(1),
+                onChanged: (value) {
+                  textSettingsBloc.add(ChangeLineHeight(value));
+                },
+              ),
+            ),
+            ListItemWidget(
+              label: 'Paragraph Indent',
+              child: Slider(
+                key: const ValueKey('paragraph_indent_slider'),
+                value: state.paragraphIndent ?? 0.0,
+                min: 0.0,
+                max: 3.0,
+                divisions: 6,
+                label: (state.paragraphIndent ?? 0.0).toStringAsFixed(1),
+                onChanged: (value) {
+                  textSettingsBloc.add(ChangeParagraphIndent(value));
+                },
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
 
-            // --- Advanced Typography (collapsible) ---
-            _CollapsibleSection(
-              title: 'Advanced Typography',
-              children: [
-                ListItemWidget(
-                  label: 'Font Weight',
-                  child: Slider(
-                    key: const ValueKey('font_weight_slider'),
-                    value: state.fontWeight,
-                    min: kIsWeb ? 1.0 : 0.5,
-                    max: kIsWeb ? 9.0 : 2.0,
-                    divisions: kIsWeb ? 8 : 6,
-                    label: kIsWeb ? (state.fontWeight * 100).toStringAsFixed(0) : state.fontWeight.toStringAsFixed(1),
-                    onChanged: (value) {
-                      textSettingsBloc.add(ChangeFontWeight(value));
-                    },
-                  ),
-                ),
-                ListItemWidget(
-                  label: 'Letter Spacing',
-                  child: Slider(
-                    key: const ValueKey('letter_spacing_slider'),
-                    value: state.letterSpacing ?? 0.0,
-                    min: -0.1,
-                    max: 0.5,
-                    divisions: 6,
-                    label: (state.letterSpacing ?? 0.0).toStringAsFixed(2),
-                    onChanged: (value) {
-                      textSettingsBloc.add(ChangeLetterSpacing(value));
-                    },
-                  ),
-                ),
-                ListItemWidget(
-                  label: 'Word Spacing',
-                  child: Slider(
-                    key: const ValueKey('word_spacing_slider'),
-                    value: state.wordSpacing ?? 0.0,
-                    min: 0.0,
-                    max: 1.0,
-                    divisions: 5,
-                    label: (state.wordSpacing ?? 0.0).toStringAsFixed(2),
-                    onChanged: (value) {
-                      textSettingsBloc.add(ChangeWordSpacing(value));
-                    },
-                  ),
-                ),
-                ListItemWidget(
-                  label: 'Line Height',
-                  child: Slider(
-                    key: const ValueKey('line_height_slider'),
-                    value: state.lineHeight ?? 1.2,
-                    min: 1.0,
-                    max: 3.0,
-                    divisions: 8,
-                    label: (state.lineHeight ?? 1.2).toStringAsFixed(1),
-                    onChanged: (value) {
-                      textSettingsBloc.add(ChangeLineHeight(value));
-                    },
-                  ),
-                ),
-                ListItemWidget(
-                  label: 'Paragraph Indent',
-                  child: Slider(
-                    key: const ValueKey('paragraph_indent_slider'),
-                    value: state.paragraphIndent ?? 0.0,
-                    min: 0.0,
-                    max: 3.0,
-                    divisions: 6,
-                    label: (state.paragraphIndent ?? 0.0).toStringAsFixed(1),
-                    onChanged: (value) {
-                      textSettingsBloc.add(ChangeParagraphIndent(value));
-                    },
-                  ),
-                ),
+class _LayoutSection extends StatelessWidget {
+  const _LayoutSection({required this.textSettingsBloc, required this.state, required this.scrollToggleDisabled});
+
+  final TextSettingsBloc textSettingsBloc;
+  final TextSettingsState state;
+  final bool scrollToggleDisabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Note (web): this toggle is structurally a no-op for publications
+        // routed to WebPubNavigator — upstream `IWebPubPreferences` has no
+        // `scroll` field, so the web mapper silently drops it. Only
+        // EPUB-profile publications (`Profile.EPUB` in `metadata.conformsTo`)
+        // honor it on web. See `flutter_readium/CLAUDE.md` "Gotchas" and
+        // `flutter_readium/web/src/preferences/FlutterWebPubPreferences.ts`
+        // (`WEBPUB_UNSUPPORTED_KEYS`). We disable the toggle on web for
+        // non-EPUB publications and surface the reason via a tooltip.
+        ListItemWidget(
+          label: 'Page Layout',
+          child: Tooltip(
+            message: scrollToggleDisabled
+                ? 'Page layout cannot be changed for this publication on web. '
+                      'Only publications that declare the EPUB profile in '
+                      'metadata.conformsTo support paginated/scroll on web.'
+                : '',
+            child: SegmentedButton<bool>(
+              key: const ValueKey('scroll_mode_selector'),
+              segments: const [
+                ButtonSegment(value: false, label: Text('Paginated')),
+                ButtonSegment(value: true, label: Text('Scroll')),
               ],
+              selected: {state.scroll},
+              onSelectionChanged: scrollToggleDisabled
+                  ? null
+                  : (values) {
+                      if (values.first != state.scroll) {
+                        textSettingsBloc.add(ToggleScrollMode());
+                      }
+                    },
             ),
-            const Divider(),
-
-            // --- Layout Section ---
-            _SectionHeader(title: 'Layout'),
-            // Note (web): this toggle is structurally a no-op for publications
-            // routed to WebPubNavigator — upstream `IWebPubPreferences` has no
-            // `scroll` field, so the web mapper silently drops it. Only
-            // EPUB-profile publications (`Profile.EPUB` in `metadata.conformsTo`)
-            // honor it on web. See `flutter_readium/CLAUDE.md` "Gotchas" and
-            // `flutter_readium/web/src/preferences/FlutterWebPubPreferences.ts`
-            // (`WEBPUB_UNSUPPORTED_KEYS`). We disable the toggle on web for
-            // non-EPUB publications and surface the reason via a tooltip.
-            ListItemWidget(
-              label: 'Page Layout',
-              child: Tooltip(
-                message: scrollToggleDisabled
-                    ? 'Page layout cannot be changed for this publication on web. '
-                          'Only publications that declare the EPUB profile in '
-                          'metadata.conformsTo support paginated/scroll on web.'
-                    : '',
-                child: SegmentedButton<bool>(
-                  key: const ValueKey('scroll_mode_selector'),
-                  segments: const [
-                    ButtonSegment(value: false, label: Text('Paginated')),
-                    ButtonSegment(value: true, label: Text('Scroll')),
-                  ],
-                  selected: {state.scroll},
-                  onSelectionChanged: scrollToggleDisabled
-                      ? null
-                      : (values) {
-                          if (values.first != state.scroll) {
-                            textSettingsBloc.add(ToggleScrollMode());
-                          }
-                        },
-                ),
-              ),
+          ),
+        ),
+        ListItemWidget(
+          label: 'Columns',
+          child: SegmentedButton<EpubColumnCount>(
+            key: const ValueKey('column_count_selector'),
+            segments: const [
+              ButtonSegment(value: EpubColumnCount.auto, label: Text('Auto')),
+              ButtonSegment(value: EpubColumnCount.one, label: Text('One')),
+              ButtonSegment(value: EpubColumnCount.two, label: Text('Two')),
+            ],
+            selected: {state.columnCount ?? EpubColumnCount.auto},
+            onSelectionChanged: (values) {
+              textSettingsBloc.add(ChangeColumnCount(values.first));
+            },
+          ),
+        ),
+        // Reading direction: native-only. The web Readium navigator derives this
+        // from the publication manifest at navigator creation time and does not
+        // accept it as a runtime preference.
+        if (!kIsWeb)
+          ListItemWidget(
+            label: 'Reading Direction',
+            child: SegmentedButton<EpubReadingProgression>(
+              key: const ValueKey('reading_progression_selector'),
+              segments: const [
+                ButtonSegment(value: EpubReadingProgression.ltr, label: Text('LTR')),
+                ButtonSegment(value: EpubReadingProgression.rtl, label: Text('RTL')),
+              ],
+              selected: {state.readingProgression ?? EpubReadingProgression.ltr},
+              onSelectionChanged: (values) {
+                textSettingsBloc.add(ChangeReadingProgression(values.first));
+              },
             ),
-            ListItemWidget(
-              label: 'Columns',
-              child: SegmentedButton<EpubColumnCount>(
-                key: const ValueKey('column_count_selector'),
-                segments: const [
-                  ButtonSegment(value: EpubColumnCount.auto, label: Text('Auto')),
-                  ButtonSegment(value: EpubColumnCount.one, label: Text('One')),
-                  ButtonSegment(value: EpubColumnCount.two, label: Text('Two')),
-                ],
-                selected: {state.columnCount ?? EpubColumnCount.auto},
-                onSelectionChanged: (values) {
-                  textSettingsBloc.add(ChangeColumnCount(values.first));
-                },
-              ),
-            ),
-            // Reading direction: native-only. The web Readium navigator derives this
-            // from the publication manifest at navigator creation time and does not
-            // accept it as a runtime preference.
-            if (!kIsWeb)
-              ListItemWidget(
-                label: 'Reading Direction',
-                child: SegmentedButton<EpubReadingProgression>(
-                  key: const ValueKey('reading_progression_selector'),
-                  segments: const [
-                    ButtonSegment(value: EpubReadingProgression.ltr, label: Text('LTR')),
-                    ButtonSegment(value: EpubReadingProgression.rtl, label: Text('RTL')),
-                  ],
-                  selected: {state.readingProgression ?? EpubReadingProgression.ltr},
-                  onSelectionChanged: (values) {
-                    textSettingsBloc.add(ChangeReadingProgression(values.first));
-                  },
-                ),
-              ),
-            const Divider(),
-
-            // --- Styling Override Section ---
-            _SectionHeader(title: 'Styling'),
+          ),
+        const Divider(),
+        _CollapsibleSection(
+          title: 'Styling',
+          initiallyExpanded: true,
+          children: [
             // Publisher Styles: native-only. The web navigator does not expose a
             // publisher-CSS toggle, IEpubPreferences overrides always apply, so the
             // toggle would have no effect on web.
@@ -247,9 +324,9 @@ class TextSettingsWidget extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: Text(
-                  'When Publisher Styles is ON, the book\u2019s original CSS is preserved and most custom '
+                  'When Publisher Styles is ON, the book’s original CSS is preserved and most custom '
                   'typography settings (font, spacing, alignment) will have no effect. '
-                  'Turn it OFF to allow your custom settings to override the publisher\u2019s styles.',
+                  'Turn it OFF to allow your custom settings to override the publisher’s styles.',
                   style: TextStyle(fontSize: 12, color: Colors.grey[600]),
                 ),
               ),
@@ -336,102 +413,52 @@ class TextSettingsWidget extends StatelessWidget {
                 },
               ),
             ),
-            const Divider(),
-
-            // --- Theme Section ---
-            _SectionHeader(title: 'Theme'),
-            ListItemWidget(
-              label: 'Color Theme',
-              child: ThemeSelectorWidget(themes: themes, isHighlight: false),
-            ),
-            ListItemWidget(
-              label: 'Image Filter',
-              child: SegmentedButton<EpubImageFilter?>(
-                key: const ValueKey('image_filter_selector'),
-                emptySelectionAllowed: true,
-                segments: const [
-                  ButtonSegment(value: EpubImageFilter.darken, label: Text('Darken')),
-                  ButtonSegment(value: EpubImageFilter.invert, label: Text('Invert')),
-                ],
-                selected: {state.imageFilter}.whereType<EpubImageFilter?>().toSet(),
-                onSelectionChanged: (values) {
-                  textSettingsBloc.add(ChangeImageFilter(values.isEmpty ? null : values.first));
-                },
-              ),
-            ),
-            const Divider(),
-            ListItemWidget(
-              label: 'Highlight',
-              child: ThemeSelectorWidget(themes: highlights, isHighlight: true),
-            ),
-            ListItemWidget(
-              label: 'Utterance',
-              child: BlocSelector<TextSettingsBloc, TextSettingsState, DecorationStyle?>(
-                selector: (state) => state.utteranceStyle,
-                builder: (context, utteranceStyle) => SegmentedButton<DecorationStyle?>(
-                  key: const ValueKey('utterance_style_selector'),
-                  emptySelectionAllowed: true,
-                  segments: const [
-                    ButtonSegment(value: null, label: Text('Off')),
-                    ButtonSegment(value: DecorationStyle.highlight, label: Text('Fill')),
-                    ButtonSegment(value: DecorationStyle.underline, label: Text('Line')),
-                    ButtonSegment(value: DecorationStyle.spotlight, label: Text('Spot')),
-                  ],
-                  selected: {utteranceStyle},
-                  onSelectionChanged: (values) =>
-                      context.read<TextSettingsBloc>().add(ChangeUtteranceStyle(values.isEmpty ? null : values.first)),
-                ),
-              ),
-            ),
-            ListItemWidget(
-              label: 'Range',
-              child: BlocSelector<TextSettingsBloc, TextSettingsState, DecorationStyle?>(
-                selector: (state) => state.rangeStyle,
-                builder: (context, rangeStyle) => SegmentedButton<DecorationStyle?>(
-                  key: const ValueKey('range_style_selector'),
-                  emptySelectionAllowed: true,
-                  segments: const [
-                    ButtonSegment(value: null, label: Text('Off')),
-                    ButtonSegment(value: DecorationStyle.highlight, label: Text('Fill')),
-                    ButtonSegment(value: DecorationStyle.underline, label: Text('Line')),
-                    ButtonSegment(value: DecorationStyle.spotlight, label: Text('Spot')),
-                  ],
-                  selected: {rangeStyle},
-                  onSelectionChanged: (values) =>
-                      context.read<TextSettingsBloc>().add(ChangeRangeStyle(values.isEmpty ? null : values.first)),
-                ),
-              ),
-            ),
-            const Divider(),
-            TextButton(
-              key: const ValueKey('text_settings_close_button'),
-              onPressed: () => Navigator.of(context).pop(),
-              style: ButtonStyle(
-                padding: WidgetStateProperty.all<EdgeInsets>(const EdgeInsets.symmetric(vertical: 16.0)),
-                shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                spacing: 8.0,
-                children: [
-                  Icon(Icons.close, size: 20),
-                  Text('Close', style: TextStyle(fontSize: 20)),
-                ],
-              ),
-            ),
           ],
         ),
-      ),
+      ],
+    );
+  }
+}
+
+class _ThemeSection extends StatelessWidget {
+  const _ThemeSection({required this.textSettingsBloc, required this.state});
+
+  final TextSettingsBloc textSettingsBloc;
+  final TextSettingsState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListItemWidget(
+          label: 'Color Theme',
+          child: ThemeSelectorWidget(themes: themes, isHighlight: false),
+        ),
+        ListItemWidget(
+          label: 'Image Filter',
+          child: SegmentedButton<EpubImageFilter?>(
+            key: const ValueKey('image_filter_selector'),
+            emptySelectionAllowed: true,
+            segments: const [
+              ButtonSegment(value: EpubImageFilter.darken, label: Text('Darken')),
+              ButtonSegment(value: EpubImageFilter.invert, label: Text('Invert')),
+            ],
+            selected: {state.imageFilter}.whereType<EpubImageFilter?>().toSet(),
+            onSelectionChanged: (values) {
+              textSettingsBloc.add(ChangeImageFilter(values.isEmpty ? null : values.first));
+            },
+          ),
+        ),
+      ],
     );
   }
 }
 
 class _CollapsibleSection extends StatelessWidget {
-  const _CollapsibleSection({required this.title, required this.children});
+  const _CollapsibleSection({required this.title, required this.children, this.initiallyExpanded = false});
   final String title;
   final List<Widget> children;
+  final bool initiallyExpanded;
 
   @override
   Widget build(BuildContext context) {
@@ -442,27 +469,8 @@ class _CollapsibleSection extends StatelessWidget {
           title,
           style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.primary),
         ),
-        initiallyExpanded: false,
+        initiallyExpanded: initiallyExpanded,
         children: children,
-      ),
-    );
-  }
-}
-
-class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.title});
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          title,
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.primary),
-        ),
       ),
     );
   }

--- a/flutter_readium/example/lib/widgets/tts_settings.widget.dart
+++ b/flutter_readium/example/lib/widgets/tts_settings.widget.dart
@@ -6,9 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_readium/flutter_readium.dart';
 
-import '../extensions/text_settings_theme.dart';
 import '../state/publication_bloc.dart';
-import '../state/text_settings_bloc.dart';
 import '../state/tts_settings_bloc.dart';
 import 'index.dart';
 
@@ -68,7 +66,7 @@ class TtsSettingsWidget extends StatelessWidget {
               ),
             ),
             const Divider(),
-            _SectionHeader(title: 'Voice'),
+            const SectionHeader(title: 'Voice'),
             if (!kIsWeb && Platform.isIOS)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -95,49 +93,7 @@ class TtsSettingsWidget extends StatelessWidget {
                   child: _VoiceDropdown(language: language),
                 ),
             const Divider(),
-            _SectionHeader(title: 'Highlight'),
-            ListItemWidget(
-              label: 'Color',
-              child: ThemeSelectorWidget(themes: highlights, isHighlight: true),
-            ),
-            ListItemWidget(
-              label: 'Utterance',
-              child: BlocSelector<TextSettingsBloc, TextSettingsState, DecorationStyle?>(
-                selector: (state) => state.utteranceStyle,
-                builder: (context, utteranceStyle) => SegmentedButton<DecorationStyle?>(
-                  key: const ValueKey('utterance_style_selector'),
-                  emptySelectionAllowed: true,
-                  segments: const [
-                    ButtonSegment(value: null, label: Text('Off')),
-                    ButtonSegment(value: DecorationStyle.highlight, label: Text('Fill')),
-                    ButtonSegment(value: DecorationStyle.underline, label: Text('Line')),
-                    ButtonSegment(value: DecorationStyle.spotlight, label: Text('Spot')),
-                  ],
-                  selected: {utteranceStyle},
-                  onSelectionChanged: (values) =>
-                      context.read<TextSettingsBloc>().add(ChangeUtteranceStyle(values.isEmpty ? null : values.first)),
-                ),
-              ),
-            ),
-            ListItemWidget(
-              label: 'Range',
-              child: BlocSelector<TextSettingsBloc, TextSettingsState, DecorationStyle?>(
-                selector: (state) => state.rangeStyle,
-                builder: (context, rangeStyle) => SegmentedButton<DecorationStyle?>(
-                  key: const ValueKey('range_style_selector'),
-                  emptySelectionAllowed: true,
-                  segments: const [
-                    ButtonSegment(value: null, label: Text('Off')),
-                    ButtonSegment(value: DecorationStyle.highlight, label: Text('Fill')),
-                    ButtonSegment(value: DecorationStyle.underline, label: Text('Line')),
-                    ButtonSegment(value: DecorationStyle.spotlight, label: Text('Spot')),
-                  ],
-                  selected: {rangeStyle},
-                  onSelectionChanged: (values) =>
-                      context.read<TextSettingsBloc>().add(ChangeRangeStyle(values.isEmpty ? null : values.first)),
-                ),
-              ),
-            ),
+            const HighlightSettingsSection(showRange: true),
             const Divider(),
             TextButton(
               key: const ValueKey('tts_settings_close_button'),
@@ -174,7 +130,14 @@ class _VoiceDropdown extends StatelessWidget {
     final ttsSettingsBloc = context.watch<TtsSettingsBloc>();
     final state = ttsSettingsBloc.state;
 
-    final matchingVoices = state.availableVoices.where((v) => v.language == language).toList();
+    // Match by primary BCP-47 subtag rather than exact equality — publications
+    // commonly declare a bare language ("da"), while device voices are
+    // region-qualified ("da-DK"), so an exact match would (almost) never hit
+    // and silently fall back to listing every voice on the device.
+    final primarySubtag = language?.split('-').first.toLowerCase();
+    final matchingVoices = state.availableVoices
+        .where((v) => v.language.split('-').first.toLowerCase() == primarySubtag)
+        .toList();
     final voices = matchingVoices.isNotEmpty ? matchingVoices : state.availableVoices;
 
     final selected = state.voicesByLanguage[language];
@@ -196,25 +159,6 @@ class _VoiceDropdown extends StatelessWidget {
             ),
           )
           .toList(),
-    );
-  }
-}
-
-class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.title});
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          title,
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.primary),
-        ),
-      ),
     );
   }
 }

--- a/flutter_readium/example/lib/widgets/tts_settings.widget.dart
+++ b/flutter_readium/example/lib/widgets/tts_settings.widget.dart
@@ -1,236 +1,220 @@
-// import 'dart:io';
+import 'dart:io';
 
-// import 'package:flutter/material.dart';
-// import 'package:flutter_bloc/flutter_bloc.dart';
-// import 'package:flutter_readium/flutter_readium.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_readium/flutter_readium.dart';
 
-// import '../state/tts_settings_bloc.dart';
-// import 'index.dart';
+import '../extensions/text_settings_theme.dart';
+import '../state/publication_bloc.dart';
+import '../state/text_settings_bloc.dart';
+import '../state/tts_settings_bloc.dart';
+import 'index.dart';
 
-// class TtsSettingsWidget extends StatefulWidget {
-//   const TtsSettingsWidget({required this.pubLang, super.key});
+class TtsSettingsWidget extends StatelessWidget {
+  const TtsSettingsWidget({super.key});
 
-//   final List<String> pubLang;
+  @override
+  Widget build(final BuildContext context) {
+    final ttsSettingsBloc = context.watch<TtsSettingsBloc>();
+    final state = ttsSettingsBloc.state;
+    final languages = context.watch<PublicationBloc>().state.publication?.metadata.languages ?? [];
+    // `null` stands in for "no declared language" — a single default voice picker.
+    final voiceLanguages = languages.isEmpty ? <String?>[null] : languages;
 
-//   @override
-//   _TtsSettingsWidgetState createState() => _TtsSettingsWidgetState();
-// }
+    return DraggableScrollableSheet(
+      initialChildSize: 0.75,
+      minChildSize: 0.4,
+      maxChildSize: 0.75,
+      expand: false,
+      builder: (context, scrollController) => SingleChildScrollView(
+        controller: scrollController,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(20.0),
+              child: Semantics(
+                header: true,
+                child: const Align(
+                  alignment: Alignment.center,
+                  child: Text('Text-to-Speech Settings', style: TextStyle(fontSize: 25)),
+                ),
+              ),
+            ),
+            const Divider(),
+            ListItemWidget(
+              label: 'Speed: ${state.speed.toStringAsFixed(2)}x',
+              child: Slider(
+                key: const ValueKey('tts_speed_slider'),
+                value: state.speed,
+                min: 0.5,
+                max: 2.0,
+                divisions: 6,
+                label: state.speed.toStringAsFixed(2),
+                onChanged: (value) => ttsSettingsBloc.add(ChangeSpeed(value)),
+              ),
+            ),
+            ListItemWidget(
+              label: 'Pitch: ${state.pitch.toStringAsFixed(2)}',
+              child: Slider(
+                key: const ValueKey('tts_pitch_slider'),
+                value: state.pitch,
+                min: 0.5,
+                max: 2.0,
+                divisions: 6,
+                label: state.pitch.toStringAsFixed(2),
+                onChanged: (value) => ttsSettingsBloc.add(ChangePitch(value)),
+              ),
+            ),
+            const Divider(),
+            _SectionHeader(title: 'Voice'),
+            if (!kIsWeb && Platform.isIOS)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: Text(
+                  'On iOS, only the most recently selected voice below takes effect — '
+                  'per-language voice switching is not yet supported by the platform.',
+                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                ),
+              ),
+            if (!state.voicesLoaded)
+              const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: CircularProgressIndicator(),
+              )
+            else if (state.availableVoices.isEmpty)
+              const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Text('No voices available'),
+              )
+            else
+              for (final language in voiceLanguages)
+                ListItemWidget(
+                  label: language ?? 'Default voice',
+                  child: _VoiceDropdown(language: language),
+                ),
+            const Divider(),
+            _SectionHeader(title: 'Highlight'),
+            ListItemWidget(
+              label: 'Color',
+              child: ThemeSelectorWidget(themes: highlights, isHighlight: true),
+            ),
+            ListItemWidget(
+              label: 'Utterance',
+              child: BlocSelector<TextSettingsBloc, TextSettingsState, DecorationStyle?>(
+                selector: (state) => state.utteranceStyle,
+                builder: (context, utteranceStyle) => SegmentedButton<DecorationStyle?>(
+                  key: const ValueKey('utterance_style_selector'),
+                  emptySelectionAllowed: true,
+                  segments: const [
+                    ButtonSegment(value: null, label: Text('Off')),
+                    ButtonSegment(value: DecorationStyle.highlight, label: Text('Fill')),
+                    ButtonSegment(value: DecorationStyle.underline, label: Text('Line')),
+                    ButtonSegment(value: DecorationStyle.spotlight, label: Text('Spot')),
+                  ],
+                  selected: {utteranceStyle},
+                  onSelectionChanged: (values) =>
+                      context.read<TextSettingsBloc>().add(ChangeUtteranceStyle(values.isEmpty ? null : values.first)),
+                ),
+              ),
+            ),
+            ListItemWidget(
+              label: 'Range',
+              child: BlocSelector<TextSettingsBloc, TextSettingsState, DecorationStyle?>(
+                selector: (state) => state.rangeStyle,
+                builder: (context, rangeStyle) => SegmentedButton<DecorationStyle?>(
+                  key: const ValueKey('range_style_selector'),
+                  emptySelectionAllowed: true,
+                  segments: const [
+                    ButtonSegment(value: null, label: Text('Off')),
+                    ButtonSegment(value: DecorationStyle.highlight, label: Text('Fill')),
+                    ButtonSegment(value: DecorationStyle.underline, label: Text('Line')),
+                    ButtonSegment(value: DecorationStyle.spotlight, label: Text('Spot')),
+                  ],
+                  selected: {rangeStyle},
+                  onSelectionChanged: (values) =>
+                      context.read<TextSettingsBloc>().add(ChangeRangeStyle(values.isEmpty ? null : values.first)),
+                ),
+              ),
+            ),
+            const Divider(),
+            TextButton(
+              key: const ValueKey('tts_settings_close_button'),
+              onPressed: () => Navigator.of(context).pop(),
+              style: ButtonStyle(
+                padding: WidgetStateProperty.all<EdgeInsets>(const EdgeInsets.symmetric(vertical: 16.0)),
+                shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(0.0)),
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                spacing: 8.0,
+                children: [
+                  Icon(Icons.close, size: 20),
+                  Text('Close', style: TextStyle(fontSize: 20)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
-// class _TtsSettingsWidgetState extends State<TtsSettingsWidget> {
-//   String? selectedLocale;
-//   ReadiumTtsVoice? selectedVoice;
+class _VoiceDropdown extends StatelessWidget {
+  const _VoiceDropdown({required this.language});
 
-//   @override
-//   void initState() {
-//     super.initState();
-//   }
+  final String? language;
 
-//   @override
-//   Widget build(final BuildContext context) => SafeArea(
-//         child: Wrap(
-//           children: [
-//             Padding(
-//               padding: const EdgeInsets.all(20.0),
-//               child: Semantics(
-//                 header: true,
-//                 child: const Align(
-//                   alignment: Alignment.center,
-//                   child: Text(
-//                     'TTS settings',
-//                     style: TextStyle(fontSize: 25),
-//                   ),
-//                 ),
-//               ),
-//             ),
-//             const Divider(),
-//             SingleChildScrollView(
-//               child: Column(
-//                 children: [
-//                   ListItemWidget(
-//                     label: 'Voice',
-//                     child: _buildVoiceOptions(context),
-//                   ),
-//                   const Divider(),
-//                   // TODO: Remember that it will only highlight paragraphs if google network voices are used. Implement this in the UI.
-//                   ListItemWidget(
-//                     label: 'Highlight',
-//                     child: BlocBuilder<TtsSettingsBloc, TtsSettingsState>(
-//                       builder: (final context, final state) {
-//                         final chosenVoices = _findVoicesByLangCode(state, widget.pubLang);
-//                         final isGoogleNetworkVoice =
-//                             chosenVoices.any((final voice) => voice.androidIsLocal == false);
-//                         final highlightModes = isGoogleNetworkVoice
-//                             ? [ReadiumHighlightMode.paragraph]
-//                             : ReadiumHighlightMode.values;
+  @override
+  Widget build(BuildContext context) {
+    final ttsSettingsBloc = context.watch<TtsSettingsBloc>();
+    final state = ttsSettingsBloc.state;
 
-//                         return SingleChildScrollView(
-//                           scrollDirection: Axis.horizontal,
-//                           child: ToggleButtons(
-//                             isSelected: highlightModes
-//                                 .map(
-//                                   (final mode) => mode == state.highlightMode,
-//                                 )
-//                                 .toList(),
-//                             selectedBorderColor: Colors.blue,
-//                             borderWidth: 4.0,
-//                             borderColor: Colors.transparent,
-//                             onPressed: (final index) {
-//                               context.read<TtsSettingsBloc>().add(
-//                                     SetTtsHighlightModeEvent(
-//                                       ReadiumHighlightMode.values[index],
-//                                     ),
-//                                   );
-//                             },
-//                             children: highlightModes
-//                                 .map(
-//                                   (final mode) => SizedBox(
-//                                     width: 120,
-//                                     child: Padding(
-//                                       padding: const EdgeInsets.symmetric(horizontal: 8.0),
-//                                       child: Center(
-//                                         child: Text(
-//                                           mode.toString().split('.').last[0].toUpperCase() +
-//                                               mode
-//                                                   .toString()
-//                                                   .split('.')
-//                                                   .last
-//                                                   .substring(1)
-//                                                   .toLowerCase(),
-//                                           style: TextStyle(fontSize: 16),
-//                                         ),
-//                                       ),
-//                                     ),
-//                                   ),
-//                                 )
-//                                 .toList(),
-//                           ),
-//                         );
-//                       },
-//                     ),
-//                   ),
-//                   const Divider(),
-//                   ListItemWidget(
-//                     label: 'Announce page numbers',
-//                     isVerticalAlignment: true,
-//                     child: BlocSelector<TtsSettingsBloc, TtsSettingsState, bool>(
-//                       selector: (final state) => state.ttsSpeakPhysicalPageIndex ?? false,
-//                       builder: (final context, final ttsSpeakPhysicalPageIndex) => Switch(
-//                         value: ttsSpeakPhysicalPageIndex,
-//                         onChanged: (final value) {
-//                           context.read<TtsSettingsBloc>().add(
-//                                 SetTtsSpeakPhysicalPageIndexEvent(value),
-//                               );
-//                         },
-//                       ),
-//                     ),
-//                   ),
-//                 ],
-//               ),
-//             ),
-//           ],
-//         ),
-//       );
+    final matchingVoices = state.availableVoices.where((v) => v.language == language).toList();
+    final voices = matchingVoices.isNotEmpty ? matchingVoices : state.availableVoices;
 
-//   Widget _buildVoiceOptions(final BuildContext context) {
-//     final ttsSettingsBloc = context.watch<TtsSettingsBloc>();
-//     final state = ttsSettingsBloc.state;
+    final selected = state.voicesByLanguage[language];
+    final selectedVoice = voices.firstWhereOrNull((v) => v.identifier == selected);
 
-//     final voices = state.voices;
-//     final voicesLocale = voices?.map((final voice) => voice.locale).toSet();
-//     final preferredVoices = state.preferredVoices;
+    return DropdownButton<ReaderTTSVoice>(
+      value: selectedVoice,
+      hint: const Text('Select voice'),
+      onChanged: (voice) {
+        if (voice != null) {
+          ttsSettingsBloc.add(ChangeVoiceForLanguage(language, voice.identifier));
+        }
+      },
+      items: voices
+          .map(
+            (voice) => DropdownMenuItem<ReaderTTSVoice>(
+              value: voice,
+              child: Text(voice.name),
+            ),
+          )
+          .toList(),
+    );
+  }
+}
 
-//     final voicesLoaded = state.loaded ?? false;
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+  final String title;
 
-//     final preferredLocale = voicesLocale != null
-//         ? preferredVoices
-//             ?.firstWhereOrNull(
-//               (final preferredVoice) => voicesLocale.contains(preferredVoice.locale),
-//             )
-//             ?.locale
-//         : null;
-
-//     final showVoiceOptions = voicesLoaded &&
-//         voices != null &&
-//         voices.isNotEmpty &&
-//         (selectedLocale != null || voicesLocale == null || voicesLocale.length == 1);
-
-//     if (!voicesLoaded) return const CircularProgressIndicator();
-//     if (voicesLoaded && (voices == null || voices.isEmpty)) {
-//       return const Text('No voices available');
-//     }
-//     if (voicesLoaded && voices != null && voices.isNotEmpty) {
-//       return Row(
-//         children: [
-//           if (voicesLocale != null && voicesLocale.length > 1)
-//             DropdownButton<String>(
-//               value: selectedLocale ?? preferredLocale,
-//               onChanged: (final locale) {
-//                 setState(() {
-//                   selectedLocale = locale;
-//                   selectedVoice = null;
-//                 });
-//               },
-//               items: voicesLocale
-//                   .map(
-//                     (final locale) => DropdownMenuItem<String>(
-//                       value: locale,
-//                       child: Text(locale),
-//                     ),
-//                   )
-//                   .toList(),
-//             ),
-//           if (showVoiceOptions)
-//             DropdownButton<ReadiumTtsVoice>(
-//               value: selectedVoice ??
-//                   preferredVoices?.firstWhereOrNull(
-//                     (final preferredVoice) => voices
-//                         .where(
-//                           (final voice) => voice.locale == selectedLocale || selectedLocale == null,
-//                         )
-//                         .contains(preferredVoice),
-//                   ),
-//               onChanged: (final voice) {
-//                 ttsSettingsBloc.add(SetTtsVoiceEvent(voice!));
-//                 setState(() {
-//                   selectedVoice = voice;
-//                 });
-//               },
-//               items: voices
-//                   .where((final voice) => voice.locale == selectedLocale || selectedLocale == null)
-//                   .map(
-//                     (final voice) => DropdownMenuItem<ReadiumTtsVoice>(
-//                       value: voice,
-//                       child: Platform.isAndroid
-//                           ? Text(_getAndroidTtsVoiceName(voice))
-//                           : Text(voice.name),
-//                     ),
-//                   )
-//                   .toList(),
-//             ),
-//         ],
-//       );
-//     }
-//     return const Text('Something went wrong. Please try again.');
-//   }
-// }
-
-// _getAndroidTtsVoiceName(final ReadiumTtsVoice voice) {
-//   final name = voice.androidVoiceName ?? voice.name;
-//   final localOrNetwork = voice.androidIsLocal == true
-//       ? ' (Local)'
-//       : voice.androidIsLocal == false
-//           ? ' (Network)'
-//           : '';
-//   return '$name$localOrNetwork';
-// }
-
-// List<ReadiumTtsVoice> _findVoicesByLangCode(
-//   final TtsSettingsState state,
-//   final List<String> pubLang,
-// ) =>
-//     state.preferredVoices
-//         ?.where(
-//           (final voice) => pubLang.contains(voice.langCode),
-//         )
-//         .toList() ??
-//     [];
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          title,
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.primary),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
@@ -301,6 +301,20 @@ public class PDFReaderView: NSObject, FlutterPlatformView, ReadiumReaderView, PD
       }
       applyDecorations(decorations, forGroup: identifier)
       result(nil)
+    case "configureSelectionActions":
+      // ReaderWidget calls this unconditionally on every reader (see
+      // reader_widget.dart), but PDF has no custom selection-action UI to
+      // configure. No-op rather than let it fall through to `default` and
+      // surface as a MissingPluginException on the Dart side.
+      Log.reader.warn("configureSelectionActions: not supported for PDF")
+      result(nil)
+    case "notifyUserNavigation":
+      // Also called unconditionally on every user tap/swipe (see
+      // reader_widget.dart's `_onInteraction`), to let narration-driven
+      // readers detect manual navigation and exit sync mode. PDF has no
+      // narration/Media Overlay concept, so this is a no-op here too.
+      Log.reader.warn("notifyUserNavigation: not supported for PDF")
+      result(nil)
     case "dispose":
       Log.reader.info("Disposing pdfViewController")
       pdfViewController.view.removeFromSuperview()


### PR DESCRIPTION
- Re-add TTS settings
- Reorganize the settings popover modals
- Show more relevant settings buttons based on open publication

Incidentally found and fixed an issue with the PDF reader:
- Fix missing method impl. in PDF ReaderView (crash on wire-up)
- Smoke-test a fully wired-upReaderView