### PR TITLE
Fix: iOS audiobook ended state

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **iOS: audiobooks no longer emit `TimebasedState.ended`** — the end-of-book
+  heuristic compared playback progress against `1.0`, but AVPlayer's reported
+  position at end-of-track rarely lines up exactly with the resource duration,
+  so the condition was never met. Now derived from the navigator's own
+  "resource finished" signal instead of a progress threshold.
+
 ## [0.2.0] - 2026-07-02
 
 ### Added

--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -12,6 +12,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   position at end-of-track rarely lines up exactly with the resource duration,
   so the condition was never met. Now derived from the navigator's own
   "resource finished" signal instead of a progress threshold.
+- **Android: audiobook `goToLocator` now waits for the seek to take effect** —
+  previously it could return before the player had moved, so a following `play()`
+  resumed from the old position (e.g. jumping to a bookmark and playing started
+  from the wrong place).
 
 ## [0.2.0] - 2026-07-02
 

--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -7,11 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **iOS: audiobooks no longer emit `TimebasedState.ended`** — the end-of-book
-  heuristic compared playback progress against `1.0`, but AVPlayer's reported
-  position at end-of-track rarely lines up exactly with the resource duration,
-  so the condition was never met. Now derived from the navigator's own
-  "resource finished" signal instead of a progress threshold.
+- **iOS: audiobooks now reliably emit `TimebasedState.ended` at end of book** —
+  the end-of-book heuristic compared playback progress against `1.0`, but AVPlayer's
+  reported position at end-of-track rarely lines up exactly with the resource
+  duration, so the condition was never met and `.ended` was never emitted. Now
+  derived from the navigator's own "resource finished" signal instead of a progress
+  threshold.
 - **Android: audiobook `goToLocator` now waits for the seek to take effect** —
   previously it could return before the player had moved, so a following `play()`
   resumed from the old position (e.g. jumping to a bookmark and playing started

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReader.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReader.kt
@@ -1374,11 +1374,16 @@ object ReadiumReader :
         val toLocator = publication.normalizeLocator(locator)
         timebasedNavigator?.let { navigator ->
             PluginLog.d(TAG, "::goToLocator - timebased $toLocator")
-            navigator.goToLocator(
+            val narrationLocator =
                 toLocator.copy(
                     text = Locator.Text(),
-                ),
-            )
+                )
+            navigator.goToLocator(narrationLocator)
+            // navigator.goToLocator blocks until the seek lands (see AudiobookNavigator),
+            // so reflect the confirmed position in state before returning. This is what a
+            // subsequent play(null) reads to resume from, closing the seek→play race.
+            currentReadiumTimebasedState.value =
+                currentReadiumTimebasedState.value.copyWith(currentLocator = narrationLocator)
 
             return
         }

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/navigators/AudiobookNavigator.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/navigators/AudiobookNavigator.kt
@@ -19,11 +19,13 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import org.readium.adapter.exoplayer.audio.ExoPlayerEngineProvider
 import org.readium.adapter.exoplayer.audio.ExoPlayerNavigatorFactory
@@ -39,11 +41,21 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.util.getOrElse
+import kotlin.math.abs
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "AudioNavigator"
+
+/** Max time [goToLocator] waits for ExoPlayer to reflect a seek before giving up. */
+private val SEEK_SETTLE_TIMEOUT = 5.seconds
+
+/**
+ * Offset tolerance when matching playback position against the seek target. ExoPlayer
+ * rarely lands exactly on the requested offset, so treat "close enough" as arrived.
+ */
+private val SEEK_MATCH_TOLERANCE = 1500.milliseconds
 
 const val CURRENT_TIMEBASE_LOCATOR_KEY = "currentTimebaseLocator"
 
@@ -211,30 +223,54 @@ open class AudiobookNavigator(
     override suspend fun goToLocator(locator: Locator) {
         val navigator = ensureNavigator()
 
-        withMainContext {
-            val itemIndex =
-                navigator.readingOrder.items
-                    .indexOfFirst { it.href == locator.href }
-                    .takeIf { it > -1 }
+        val targetSeek =
+            withMainContext {
+                val itemIndex =
+                    navigator.readingOrder.items
+                        .indexOfFirst { it.href == locator.href }
+                        .takeIf { it > -1 }
 
-            if (itemIndex == null) {
-                PluginLog.e(
-                    TAG,
-                    "::goToLocator - ${locator.href} not found in navigator's readingOrder",
-                )
-                return@withMainContext
-            }
+                if (itemIndex == null) {
+                    PluginLog.e(
+                        TAG,
+                        "::goToLocator - ${locator.href} not found in navigator's readingOrder",
+                    )
+                    return@withMainContext null
+                }
 
-            val item = navigator.readingOrder.items[itemIndex]
-            val timeOffset = locator.locations.timeWithDuration(item.duration)
-            if (timeOffset == null) {
-                PluginLog.w(
-                    TAG,
-                    "::goToLocator - couldn't find timeOffset from starting file over.",
-                )
-            }
-            navigator.skipTo(itemIndex, timeOffset ?: Duration.ZERO)
-            return@withMainContext
+                val item = navigator.readingOrder.items[itemIndex]
+                val timeOffset = locator.locations.timeWithDuration(item.duration)
+                if (timeOffset == null) {
+                    PluginLog.w(
+                        TAG,
+                        "::goToLocator - couldn't find timeOffset from starting file over.",
+                    )
+                }
+
+                val resolvedOffset = timeOffset ?: Duration.ZERO
+                navigator.skipTo(itemIndex, resolvedOffset)
+                itemIndex to resolvedOffset
+            } ?: return
+
+        val (targetItemIndex, targetOffset) = targetSeek
+
+        // skipTo() is fire-and-forget: ExoPlayer applies the seek asynchronously, so
+        // navigator.playback still reports the old index/offset for a short window. Block
+        // until it reflects the target before returning, so an awaited goToLocator followed
+        // by play(null) resumes from the seeked position rather than the stale one.
+        val didReachTarget =
+            withTimeoutOrNull(SEEK_SETTLE_TIMEOUT) {
+                navigator.playback.first { playback ->
+                    playback.index == targetItemIndex &&
+                        abs((playback.offset - targetOffset).inWholeMilliseconds) <= SEEK_MATCH_TOLERANCE.inWholeMilliseconds
+                }
+            } != null
+
+        if (!didReachTarget) {
+            PluginLog.w(
+                TAG,
+                "::goToLocator - timed out waiting for playback index=$targetItemIndex @ $targetOffset after skipTo(${locator.href})",
+            )
         }
     }
 

--- a/flutter_readium/example/integration_test/plugin_integration_test.dart
+++ b/flutter_readium/example/integration_test/plugin_integration_test.dart
@@ -947,6 +947,73 @@ void main() {
           reason: 'audioSeekBy() should have advanced offset by ~seekDuration',
         );
       });
+
+      test('audiobook emits ended state when playback reaches end of book', () async {
+        await reader.setLogLevel(LogLevel.debug);
+        addTearDown(() => reader.setLogLevel(LogLevel.info));
+
+        final path = fixturePaths['38533.audiobook'];
+        expect(path, isNotNull, reason: 'Fixture 38533.audiobook missing from asset bundle');
+
+        final pub = await reader.openPublication(path!);
+        expect(pub.readingOrder, isNotEmpty);
+
+        // Seek to just before the end of the LAST reading-order resource so the
+        // tail plays out quickly rather than playing the whole book.
+        final lastIndex = pub.readingOrder.length - 1;
+        final lastLink = pub.readingOrder[lastIndex];
+        final lastDuration = lastLink.duration;
+        expect(
+          lastDuration != null && lastDuration.isFinite && lastDuration > 3,
+          isTrue,
+          reason:
+              'Test requires the last resource to have a finite duration > 3s '
+              '(got $lastDuration) to seek near its end',
+        );
+        // Play out the final ~2s of the book.
+        final beginSeconds = lastDuration! - 2;
+
+        final states = <ReadiumTimebasedState>[];
+        final sub = reader.onTimebasedPlayerStateChanged.listen(states.add);
+        addTearDown(sub.cancel);
+
+        await reader.audioEnable(prefs: AudioPreferences(speed: 1.0));
+
+        final endLocator = Locator(
+          href: lastLink.href,
+          type: lastLink.type ?? 'audio/mpeg',
+          locations: Locations(
+            // Position is 1-based (matches upstream); last resource == length.
+            position: pub.readingOrder.length,
+            fragments: ['t=$beginSeconds'],
+          ),
+        );
+        final navigated = await reader.goToLocator(endLocator);
+        expect(navigated, isTrue, reason: 'goToLocator to end of last resource should succeed');
+
+        await reader.play(null);
+
+        await _waitUntil(
+          () => states.any((s) => s.state == TimebasedState.ended),
+          timeout: const Duration(seconds: 30),
+          reason:
+              'Playback reached end of book but no TimebasedState.ended was emitted. '
+              'Last state seen: ${states.isEmpty ? "<none>" : states.last.state}',
+        );
+
+        // A trailing state update (e.g. the player settling to paused right after
+        // finishing) must not clobber ended — it should be the final, stable state.
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+        expect(
+          states.last.state,
+          equals(TimebasedState.ended),
+          reason:
+              'ended was reported but a later state overwrote it as the last emission: '
+              '${states.last.state}',
+        );
+
+        await reader.pause();
+      });
     },
   );
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterAudioNavigator.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterAudioNavigator.swift
@@ -368,7 +368,10 @@ public class FlutterAudioNavigator: FlutterTimebasedNavigator, AudioNavigatorDel
   /// equal to the resource duration.
   public func navigator(_ navigator: AudioNavigator, shouldPlayNextResource info: MediaPlaybackInfo) -> Bool {
     if !canGoForward {
+      Log.navigator.info("Resource \(info.resourceIndex) finished — no next resource, publication ended")
       submitEndedStateToListener(info: info)
+    } else {
+      Log.navigator.debug("Resource \(info.resourceIndex) finished, advancing to next resource")
     }
     return true
   }
@@ -465,6 +468,7 @@ public class FlutterAudioNavigator: FlutterTimebasedNavigator, AudioNavigatorDel
     // If state has changed, submit it to listener.
     if (timebasedState != self._lastTimebasedPlayerState) {
       self._lastTimebasedPlayerState = timebasedState
+      Log.navigator.debug("Submitting state=\(timebasedState.state) resourceIndex=\(info.resourceIndex) progress=\(info.progress)")
       self.listener?.timebasedNavigator(self, didChangeState: timebasedState)
     } else {
       Log.navigator.debug("Skipped state emission - duplicate")
@@ -492,6 +496,7 @@ public class FlutterAudioNavigator: FlutterTimebasedNavigator, AudioNavigatorDel
 
     if (timebasedState != self._lastTimebasedPlayerState) {
       self._lastTimebasedPlayerState = timebasedState
+      Log.navigator.debug("Submitting state=ended resourceIndex=\(info.resourceIndex) progress=\(info.progress)")
       self.listener?.timebasedNavigator(self, didChangeState: timebasedState)
     } else {
       Log.navigator.debug("Skipped state emission - duplicate")

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterAudioNavigator.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/navigator/FlutterAudioNavigator.swift
@@ -10,6 +10,11 @@ public class FlutterAudioNavigator: FlutterTimebasedNavigator, AudioNavigatorDel
   internal var _initialLocator: Locator?
   internal var _preferences: FlutterAudioPreferences
   internal var _lastTimebasedPlayerState: ReadiumTimebasedState?
+  /// Resource index `.ended` was last submitted for. AVPlayer's `timeControlStatus` can
+  /// settle to `.paused` a few milliseconds after `shouldPlayNextResource` reports the
+  /// resource finished, and that trailing update still flows through the throttled
+  /// `$playback` pipeline — without this guard it silently overwrites `.ended`.
+  private var _endedResourceIndex: Int?
   internal var _nowPlayingUpdater: NowPlayingInfoUpdater
   @MainActor internal var _audioNavigator: AudioNavigator?
 
@@ -354,7 +359,17 @@ public class FlutterAudioNavigator: FlutterTimebasedNavigator, AudioNavigatorDel
 
   /// Called when the navigator finished playing the current resource.
   /// Returns whether the next resource should be played. Default is true.
+  ///
+  /// Fires from `AVPlayerItemDidPlayToEndTime`, before any auto-advance — this is the
+  /// authoritative "resource finished" signal (mirrors the web bridge's `trackEnded`).
+  /// When there's no next resource, the publication has ended: submit `.ended` directly
+  /// here rather than relying on `info.progress >= 1.0` in the throttled `$playback`
+  /// pipeline, since AVPlayer's reported currentTime at end-of-track is rarely exactly
+  /// equal to the resource duration.
   public func navigator(_ navigator: AudioNavigator, shouldPlayNextResource info: MediaPlaybackInfo) -> Bool {
+    if !canGoForward {
+      submitEndedStateToListener(info: info)
+    }
     return true
   }
 
@@ -433,11 +448,48 @@ public class FlutterAudioNavigator: FlutterTimebasedNavigator, AudioNavigatorDel
   }
 
   internal func submitTimebasedPlayerStateToListener(info: MediaPlaybackInfo, location: Locator?, bufferedInterval: TimeInterval? = nil) {
+    if let endedIndex = _endedResourceIndex {
+      if info.resourceIndex == endedIndex && info.state == .paused {
+        // AVPlayer settling to .paused right after we reported .ended for this resource.
+        Log.navigator.debug("Skipped state emission - resource \(endedIndex) already reported ended")
+        return
+      }
+      // Any other transition (new resourceIndex, or .playing/.loading on the same one) means
+      // playback moved on for real; stop suppressing.
+      _endedResourceIndex = nil
+    }
 
     /// Create TimebasedState and send it over the timebased-state stream.
     let timebasedState = mapToTimebasedState(info: info, location: location, bufferedInterval: bufferedInterval)
 
     // If state has changed, submit it to listener.
+    if (timebasedState != self._lastTimebasedPlayerState) {
+      self._lastTimebasedPlayerState = timebasedState
+      self.listener?.timebasedNavigator(self, didChangeState: timebasedState)
+    } else {
+      Log.navigator.debug("Skipped state emission - duplicate")
+    }
+  }
+
+  /// Submits the terminal `.ended` state directly, bypassing the throttled `$playback`
+  /// pipeline. See `navigator(_:shouldPlayNextResource:)` for why.
+  private func submitEndedStateToListener(info: MediaPlaybackInfo) {
+    var locator = audioLocator
+    locator?.locations.position = info.resourceIndex + 1
+    locator = locator?.toClientFriendlyLocator()
+    locator?.locations.totalProgression = 1.0
+
+    let timebasedState = ReadiumTimebasedState(
+      state: .ended,
+      currentOffset: info.time,
+      currentDuration: info.duration,
+      totalProgressDuration: makeTotalProgressDuration(locator),
+      totalDuration: makePublicationDuration(),
+      currentLocator: locator
+    )
+
+    _endedResourceIndex = info.resourceIndex
+
     if (timebasedState != self._lastTimebasedPlayerState) {
       self._lastTimebasedPlayerState = timebasedState
       self.listener?.timebasedNavigator(self, didChangeState: timebasedState)
@@ -481,13 +533,7 @@ public class FlutterAudioNavigator: FlutterTimebasedNavigator, AudioNavigatorDel
     }
 
     /// Fetch MediaPlaybackState and convert it to TimebasedState
-    var playerState = info.state.asTimebasedState
-    if (info.state == .paused && info.progress >= 1.0 && info.resourceIndex == self.publication.manifest.readingOrder.count - 1) {
-      /// If paused at progress 1 of the last resource in readingOrder, we can assume the book has ended.
-      playerState = .ended
-      /// FIX: totalProgression will be very close to 1.0, but not always exactly there, so we have to force it.
-      locator?.locations.totalProgression = 1.0
-    }
+    let playerState = info.state.asTimebasedState
 
     let totalProgressDuration = makeTotalProgressDuration(locator)
     let totalDuration = makePublicationDuration()

--- a/flutter_readium_platform_interface/CHANGELOG.md
+++ b/flutter_readium_platform_interface/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- `Properties.toJson()` emitted the `orientation`, `layout`, `overflow` and `spread`
+  presentation hints as raw enum instances instead of their string names, so
+  `jsonEncode`-ing a serialized `Publication` threw for fixed-layout (FXL) resources
+  (e.g. `Converting object to an encodable object failed: Instance of 'EpubLayout'`).
+  They now serialize as strings and round-trip through `fromJson`.
+
 ## [0.2.0] - 2026-07-02
 
 ### Added

--- a/flutter_readium_platform_interface/lib/src/shared/publication/properties.dart
+++ b/flutter_readium_platform_interface/lib/src/shared/publication/properties.dart
@@ -71,10 +71,10 @@ class Properties extends AdditionalProperties with EquatableMixin implements JSO
   Map<String, dynamic> toJson() => Map<String, dynamic>.of(additionalProperties)
     ..putOpt('page', page?.name)
     ..putIterableIfNotEmpty('contains', contains)
-    ..putOpt('orientation', orientation)
-    ..putOpt('layout', layout)
-    ..putOpt('overflow', overflow)
-    ..putOpt('spread', spread)
+    ..putOpt('orientation', orientation?.name)
+    ..putOpt('layout', layout?.name)
+    ..putOpt('overflow', overflow?.name)
+    ..putOpt('spread', spread?.name)
     ..putOpt('encryption', encryption);
 
   Properties copyWith({

--- a/flutter_readium_platform_interface/test/models_test.dart
+++ b/flutter_readium_platform_interface/test/models_test.dart
@@ -519,4 +519,45 @@ void main() {
       expect(prefs.toJson()['fontSize'], closeTo(2.5, 1e-9));
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Properties serialisation
+  // ---------------------------------------------------------------------------
+  group('Properties', () {
+    test('toJson emits presentation enums as their string names', () {
+      final json = Properties(
+        orientation: PresentationOrientation.landscape,
+        layout: EpubLayout.fixed,
+        overflow: PresentationOverflow.paginated,
+        spread: PresentationSpread.both,
+      ).toJson();
+
+      expect(json['orientation'], 'landscape');
+      expect(json['layout'], 'fixed');
+      expect(json['overflow'], 'paginated');
+      expect(json['spread'], 'both');
+    });
+
+    test('toJson output is json-encodable for a fixed-layout resource', () {
+      // Regression: raw EpubLayout (and sibling enums) leaked into toJson,
+      // so jsonEncode threw for FXL publications (HydratedUnsupportedError).
+      final json = Properties(layout: EpubLayout.fixed).toJson();
+      expect(() => jsonEncode(json), returnsNormally);
+    });
+
+    test('round-trips presentation enums through toJson / fromJson', () {
+      final properties = Properties(
+        orientation: PresentationOrientation.landscape,
+        layout: EpubLayout.fixed,
+        overflow: PresentationOverflow.paginated,
+        spread: PresentationSpread.both,
+      );
+      final restored = Properties.fromJson(properties.toJson());
+
+      expect(restored.orientation, PresentationOrientation.landscape);
+      expect(restored.layout, EpubLayout.fixed);
+      expect(restored.overflow, PresentationOverflow.paginated);
+      expect(restored.spread, PresentationSpread.both);
+    });
+  });
 }


### PR DESCRIPTION
- The manual .ended emit was dependent on the AudioNavigator emitting exactly 1.0 as progress, which did not always happens.
- Now uses a much more reliable way of tracking the end of the last resource.
- Added integration regression test for this issue.