### PR TITLE
fix: Add missing dependencies on iOS for Flutter 3.44

### DIFF
--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView+Decorations.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView+Decorations.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumNavigator
 import ReadiumShared
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView+Navigation.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView+Navigation.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumNavigator
 import ReadiumShared
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView+Preferences.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView+Preferences.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ReadiumNavigator
 import ReadiumShared
 


### PR DESCRIPTION
# Description

When Flutter 3.44 is used and run on an iOS device/simulator, errors will be thrown from _flutter_readium_ about missing imports. This will fix that. 