### PR TITLE
fix: missing js and css files in published package

### DIFF
--- a/.github/actions/build-web-reader-bundle/action.yml
+++ b/.github/actions/build-web-reader-bundle/action.yml
@@ -19,7 +19,5 @@ runs:
         cache-dependency-path: flutter_readium/package-lock.json
     - name: Build & copy web reader bundle
       shell: bash
-      run: >
-        npm ci --ignore-scripts
-        npm run build
+      run: npm ci --ignore-scripts && npm run build
       working-directory: flutter_readium

--- a/.github/actions/build-webview-helpers/action.yml
+++ b/.github/actions/build-webview-helpers/action.yml
@@ -19,7 +19,5 @@ runs:
         cache-dependency-path: flutter_readium/assets/_helper_scripts/package-lock.json
     - name: Build webview helper assets
       shell: bash
-      run: >
-        npm ci --ignore-scripts
-        npm run build
+      run: npm ci --ignore-scripts && npm run build
       working-directory: flutter_readium/assets/_helper_scripts

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"type": "npm",
-			"script": "build:helpers",
+			"script": "build:helpers:dev",
 			"path": "flutter_readium",
 			"group": "build",
 			"problemMatcher": [],

--- a/bin/publish
+++ b/bin/publish
@@ -173,6 +173,12 @@ build_staged_web_bundle() {
   find "$pkg_dir/build" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
 
   "$PROJECT_ROOT/bin/build_js" --skip-example-copy "$pkg_dir"
+
+  # Build helpers (web/TS source is gitignored; compiled output goes into assets/helpers/)
+  if [ ! -d "$pkg_dir/assets/_helper_scripts/node_modules" ]; then
+    npm ci --prefix "$pkg_dir/assets/_helper_scripts"
+  fi
+  npm run build:helpers --prefix "$pkg_dir"
 }
 
 for pkg in "${PACKAGES[@]}"; do


### PR DESCRIPTION
## Problem

v0.3.1 was published without the compiled `flutterReadiumTools.js` and `flutterReadiumTools.css` files in `assets/helpers/`. The same issue affects the web reader bundle.

## Root cause

Both composite actions used a YAML fold scalar (`>`) to split the `run` command across two lines:

```yaml
run: >
  npm ci --ignore-scripts
  npm run build
```

YAML fold scalars convert newlines to spaces, so bash receives this as a **single command**:

```bash
npm ci --ignore-scripts npm run build
```

That's `npm ci` with extra positional arguments (`npm`, `run`, `build`) — not two separate commands. The build never runs, so the gitignored `.js`/`.css` files are never created and `dart pub publish` ships without them.

## Fix

Collapse each `run` block into a single line with `&&` between the commands:

```yaml
run: npm ci --ignore-scripts && npm run build
```

## Files changed

- `.github/actions/build-webview-helpers/action.yml` — native webview helpers (iOS/Android)
- `.github/actions/build-web-reader-bundle/action.yml` — web navigator bundle
- `bin/publish` — added helper build step for local publishing
- `.vscode/tasks.json` — minor task config update