### PR TITLE
fix(android): don't crash on app exit when detach() runs twice

### DIFF
--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReader.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReader.kt
@@ -456,6 +456,16 @@ object ReadiumReader :
     }
 
     fun detach() {
+        // `detach()` runs twice on shutdown: once from `onDetachedFromActivity` and once
+        // from `onDetachedFromEngine`. The first call clears `appRef`, so the second one
+        // crashes the app in `closePublication() -> ResourceFileCache.purgeAll()`, which
+        // reads `application` and throws IllegalStateException. Nothing is left to release
+        // at that point, so return early.
+        if (appRef?.get() == null && activityRef?.get() == null) {
+            PluginLog.d(TAG, "::detach - already detached, nothing to do")
+            return
+        }
+
         closePublication()
 
         appRef?.clear()


### PR DESCRIPTION
Fixes #199.

`FlutterReadiumPlugin` calls `ReadiumReader.detach()` from both `onDetachedFromActivity()` and `onDetachedFromEngine()`. Both fire when the activity is destroyed, so the second call runs after `appRef` has been cleared, enters `closePublication()` and throws `IllegalStateException` from `ResourceFileCache.purgeAll()` — inside `onDestroy`, so it kills the app on every exit.

This returns early when neither the application nor the activity reference is left, which is exactly the state the second call sees. Nothing is released twice and the first call is unchanged.

Happy to move the guard into `ResourceFileCache` instead if you would rather have it cover a `closePublication()` arriving from Dart after detach — see the note in the issue.