### PR TITLE
fix: unblock the iOS build on Swift 6 and Android text selection on first mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ Then complete the per-platform setup below. See [docs/getting-started/installati
 ### Android
 
 - Set `minSdkVersion` to 24 or higher in `android/app/build.gradle`.
+- Enable [core library desugaring](https://developer.android.com/studio/write/java8-support) — the
+  readium-kotlin-toolkit artifacts require it, and the build fails at `checkDebugAarMetadata`
+  without it:
+
+  ```kotlin
+  android {
+      compileOptions {
+          isCoreLibraryDesugaringEnabled = true
+      }
+  }
+
+  dependencies {
+      coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+  }
+  ```
 - Change your `MainActivity` to extend `FlutterFragmentActivity` (not `FlutterActivity`) — otherwise the reader view will crash at runtime.
 - If using TTS or background audio, add to `android/app/src/main/AndroidManifest.xml`:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -36,6 +36,29 @@ android {
 }
 ```
 
+### Core library desugaring
+
+The readium-kotlin-toolkit artifacts require it. In `android/app/build.gradle`:
+
+```gradle
+android {
+  compileOptions {
+    coreLibraryDesugaringEnabled true
+  }
+}
+
+dependencies {
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
+}
+```
+
+Without this the build fails at `:app:checkDebugAarMetadata` with one error per readium artifact:
+
+```
+Dependency 'org.readium.kotlin-toolkit:readium-shared:3.3.0' requires core library desugaring
+to be enabled for :app.
+```
+
 ### Fragment activity
 
 The plugin uses platform views that require Fragment support. Change your `MainActivity` to extend `FlutterFragmentActivity`:
@@ -46,7 +69,14 @@ import io.flutter.embedding.android.FlutterFragmentActivity
 class MainActivity : FlutterFragmentActivity()
 ```
 
-Without this you will see: `MainActivity cannot be cast to androidx.fragment.app.FragmentActivity`.
+Without this the app still builds and launches — it only fails when a publication is opened, and
+the reader view stays on its loading state:
+
+```
+java.lang.IllegalStateException: ::activity. No FragmentActivity available
+  — is the plugin attached to a FragmentActivity host?
+  at dk.nota.flutterreadium.ReadiumReaderWidget.getActivity(ReadiumReaderWidget.kt:73)
+```
 
 ### Optional permissions
 

--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -11,6 +11,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   system media controls such as headphones, iOS Control Center, and Android
   media-session controls.
 
+### Fixed
+
+- **iOS build failure on Swift 6.** `utils/Extensions.swift` had no import statements while using
+  `NSEC_PER_SEC`, which comes from `Darwin`. It resolved only because Swift used to leak imports
+  between files of the same compilation unit; Swift 6 does not, so the file failed to compile with
+  `Cannot find 'NSEC_PER_SEC' in scope`.
+- **Text selection was dead on the first mount of the reader on Android.** `onTextSelected` never
+  fired and custom selection actions never appeared, with nothing logged. `selectionActions` is now
+  read from the creation params — as iOS already did — so it is known before the navigator fragment
+  is built, instead of relying on the later `configureSelectionActions` call.
+
+### Documentation
+
+- Document the core library desugaring requirement in the installation guide and the README, and
+  correct the error message shown when `MainActivity` does not extend `FlutterFragmentActivity`.
+
 ## [0.4.0] - 2026-08-17
 
 ### Added

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReaderWidget.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReaderWidget.kt
@@ -120,6 +120,24 @@ class ReadiumReaderWidget(
                 FlutterInjector.instance().flutterLoader().getLookupKeyForAsset(asset)
             }
 
+        // Selection actions must be known BEFORE the navigator fragment is built, because
+        // EpubReaderFragment decides `selectionActionModeCallback` from
+        // `ReadiumReader.selectionActions` and a null callback means `onTextSelected` never
+        // fires. The `configureSelectionActions` method call arrives after this widget is
+        // constructed, so relying on it alone leaves selection dead on the first mount —
+        // the singleton only happens to be populated from the second reader onwards.
+        // iOS already reads the same key straight from the creation params.
+        @Suppress("UNCHECKED_CAST")
+        val selectionActionsParam =
+            creationParams["selectionActions"] as? List<Map<String, String>> ?: emptyList()
+        ReadiumReader.selectionActions =
+            selectionActionsParam.map { map ->
+                SelectionActionConfig(
+                    id = map["id"] ?: "",
+                    title = map["title"] ?: "",
+                )
+            }
+
         // Accepted for API parity with iOS but currently no-op: kotlin-toolkit's
         // EpubNavigatorFragment.Configuration does not expose preload-count fields
         // (preload is governed by an internal R2ViewPager.offscreenPageLimit). Revisit

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/utils/Extensions.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/utils/Extensions.swift
@@ -1,3 +1,8 @@
+// `NSEC_PER_SEC` below comes from the `Darwin` module, re-exported by `Foundation`.
+// It used to resolve without an explicit import because Swift leaked imports between
+// files of the same compilation unit; Swift 6 no longer does, so the file fails to
+// build with "Cannot find 'NSEC_PER_SEC' in scope".
+import Foundation
 
 func clamp<T>(_ value: T, minValue: T, maxValue: T) -> T where T : Comparable {
   return min(max(value, minValue), maxValue)


### PR DESCRIPTION
Two independent defects found while evaluating 0.4.0 on a real device, on both platforms.

## 1. iOS does not build on Swift 6

`flutter_readium/ios/.../utils/Extensions.swift` has **no import statements at all**, yet uses
`NSEC_PER_SEC`, which comes from the `Darwin` module re-exported by `Foundation`.

It used to resolve because Swift leaked imports between files of the same compilation unit.
Swift 6 no longer does, so on Xcode 26 / Swift 6.3 the build fails with:

```
Swift Compiler Error (Xcode): Cannot find 'NSEC_PER_SEC' in scope
.../flutter_readium/utils/Extensions.swift:56:51
```

Fixed by adding `import Foundation`. Everything else in the file is stdlib and `_Concurrency`.

## 2. Text selection is dead on the first mount of the reader on Android

**Symptom:** `onTextSelected` never fires, custom selection actions never show up, and nothing is
logged. Closing the book and reopening it makes selection work, which makes the bug look
intermittent.

**Cause:** `EpubReaderFragment` derives `selectionActionModeCallback` from the
`ReadiumReader.selectionActions` singleton while building the navigator, and a `null` callback
means the `ActionMode.Callback` is never registered — so `onTextSelected` can never fire. That
singleton is only populated by the `configureSelectionActions` method call, which Dart sends
*after* the platform view has been constructed:

1. Flutter creates the platform view.
2. `ReadiumReaderWidget.<init>` → `EpubReaderFragment` builds the navigator. `selectionActions` is
   still empty here, so the callback is set to `null`.
3. Only now does Dart call `configureSelectionActions` — the navigator already exists.

Because the singleton is an `object` and survives between mounts, selection appears to work from
the second reader onwards. That is exactly what makes it easy to misdiagnose.

**Fix:** Dart already sends `selectionActions` in the creation params to *both* platforms
(`reader_widget.dart`), and iOS reads it there (`EPUBReaderView`). Android now does the same, so
the value is known before the fragment is built. Setting it unconditionally — empty when the key
is absent — also stops the singleton from leaking actions from a previously mounted reader.

## 3. Documentation

- The core library desugaring requirement was not documented. Without it the build fails at
  `:app:checkDebugAarMetadata` with one error per readium artifact, and the message does not point
  back to any setup step. Added to both the README and the installation guide.
- Corrected the symptom described for a `MainActivity` that does not extend
  `FlutterFragmentActivity`: the app builds and launches fine, and only fails when a publication is
  opened, with an `IllegalStateException` from `ReadiumReaderWidget.getActivity` rather than a
  `ClassCastException`.

## Testing

- Verified on a real device on **both iOS and Android**: opens an EPUB, paginates, saves and
  restores a `Locator` across a close/reopen cycle, applies an underline decoration on a text
  selection, and keeps that decoration anchored across a font-size change.
- Text selection now works on the **first** mount on Android, which was the failing case.
- `CHANGELOG.md` updated under Unreleased. No Dart code is touched by this PR.