### PR TITLE
fix(platform-interface): drop malformed native locator/state events

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -13,12 +13,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Native locator/player-state serialization failures were silently swallowed
-  (iOS).** A `Locator` or `ReadiumTimebasedState` that failed to serialize sent a
-  bare `nil` to the text-locator / timebased-state event channels with nothing in
-  the native logs to explain the resulting gap in reader-position updates. The
-  failure is now logged instead (paired with the platform-interface fix that drops
-  such events rather than raising them on the Dart stream).
+- **A reader-position event that failed to serialize left no trace (iOS).** The
+  position update went missing with nothing in the native logs to explain it.
+  Such failures are now logged, and the Dart stream drops the bad event instead
+  of raising an uncaught async error.
 - **iOS build failed on Swift 6.** Building with Xcode 26 / Swift 6.3 stopped with
   `Cannot find 'NSEC_PER_SEC' in scope`. The timeout helper used that `Darwin` macro from a file
   with no imports, which only resolved because older Swift leaked imports between files of one

--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -17,8 +17,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (iOS).** A `Locator` or `ReadiumTimebasedState` that failed to serialize sent a
   bare `nil` to the text-locator / timebased-state event channels with nothing in
   the native logs to explain the resulting gap in reader-position updates. The
-  failure is now logged instead (paired with the platform-interface fix that keeps
-  the Dart stream alive when this happens).
+  failure is now logged instead (paired with the platform-interface fix that drops
+  such events rather than raising them on the Dart stream).
 
 ## [0.4.0] - 2026-08-17
 

--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -11,6 +11,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   system media controls such as headphones, iOS Control Center, and Android
   media-session controls.
 
+### Fixed
+
+- **Native locator/player-state serialization failures were silently swallowed
+  (iOS).** A `Locator` or `ReadiumTimebasedState` that failed to serialize sent a
+  bare `nil` to the text-locator / timebased-state event channels with nothing in
+  the native logs to explain the resulting gap in reader-position updates. The
+  failure is now logged instead (paired with the platform-interface fix that keeps
+  the Dart stream alive when this happens).
+
 ## [0.4.0] - 2026-08-17
 
 ### Added

--- a/flutter_readium/example/pubspec.lock
+++ b/flutter_readium/example/pubspec.lock
@@ -177,14 +177,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.3"
+    version: "0.4.0"
   flutter_readium_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../../flutter_readium_platform_interface"
       relative: true
     source: path
-    version: "0.3.3"
+    version: "0.4.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/FlutterReadiumPlugin.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/FlutterReadiumPlugin.swift
@@ -348,7 +348,11 @@ public class FlutterReadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.Warnin
           let wasMO = self.timebasedNavigator is FlutterMediaOverlayNavigator
           self.timebasedNavigator?.dispose()
           self.timebasedNavigator = nil
-          self.timebasedPlayerStateStreamHandler?.sendEvent(ReadiumTimebasedState(state: .none).toJsonString())
+          if let json = ReadiumTimebasedState(state: .none).toJsonString() {
+            self.timebasedPlayerStateStreamHandler?.sendEvent(json)
+          } else {
+            Log.navigator.error("Failed to serialize timebased-state .none sentinel")
+          }
           self.updateReaderViewTimebasedDecorations([])
           if wasMO {
             self.currentReaderView?.setMOActive(false)
@@ -707,7 +711,11 @@ public class FlutterReadiumPlugin: NSObject, FlutterPlugin, ReadiumShared.Warnin
 
       Task { @MainActor [state] in
         self.lastTimebasedPlayerState = state
-        self.timebasedPlayerStateStreamHandler?.sendEvent(state.toJsonString())
+        if let json = state.toJsonString() {
+          self.timebasedPlayerStateStreamHandler?.sendEvent(json)
+        } else {
+          Log.navigator.error("Failed to serialize timebased player state: \(state.state)")
+        }
       }
     }
   }

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView.swift
@@ -454,7 +454,13 @@ public class EPUBReaderView: NSObject, FlutterPlatformView, ReadiumReaderView, E
       let finalLocator = enriched ?? locator
       await MainActor.run() {
         self.channel.onPageChanged(locator: finalLocator)
-        FlutterReadiumPlugin.instance?.textLocatorStreamHandler?.sendEvent(try? finalLocator.jsonString())
+        do {
+          FlutterReadiumPlugin.instance?.textLocatorStreamHandler?.sendEvent(try finalLocator.jsonString())
+        } catch {
+          // `try?` used to swallow this: a serialization failure silently stopped
+          // Dart's text-locator stream from ever seeing another event.
+          Log.reader.error("Failed to serialize locator for text-locator stream: \(error)")
+        }
       }
     }
   }

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView.swift
@@ -457,8 +457,8 @@ public class EPUBReaderView: NSObject, FlutterPlatformView, ReadiumReaderView, E
         do {
           FlutterReadiumPlugin.instance?.textLocatorStreamHandler?.sendEvent(try finalLocator.jsonString())
         } catch {
-          // `try?` used to swallow this: a serialization failure silently stopped
-          // Dart's text-locator stream from ever seeing another event.
+          // `try?` used to discard this error, so a serialization failure left no
+          // trace anywhere: no event on the stream and nothing in the logs.
           Log.reader.error("Failed to serialize locator for text-locator stream: \(error)")
         }
       }

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
@@ -233,8 +233,8 @@ public class PDFReaderView: NSObject, FlutterPlatformView, ReadiumReaderView, PD
         do {
           FlutterReadiumPlugin.instance?.textLocatorStreamHandler?.sendEvent(try finalLocator.jsonString())
         } catch {
-          // `try?` used to swallow this: a serialization failure silently stopped
-          // Dart's text-locator stream from ever seeing another event.
+          // `try?` used to discard this error, so a serialization failure left no
+          // trace anywhere: no event on the stream and nothing in the logs.
           Log.reader.error("Failed to serialize locator for text-locator stream: \(error)")
         }
       }

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
@@ -230,7 +230,13 @@ public class PDFReaderView: NSObject, FlutterPlatformView, ReadiumReaderView, PD
       let finalLocator = resultLocator
       await MainActor.run() {
         self.channel.onPageChanged(locator: finalLocator)
-        FlutterReadiumPlugin.instance?.textLocatorStreamHandler?.sendEvent(try? finalLocator.jsonString())
+        do {
+          FlutterReadiumPlugin.instance?.textLocatorStreamHandler?.sendEvent(try finalLocator.jsonString())
+        } catch {
+          // `try?` used to swallow this: a serialization failure silently stopped
+          // Dart's text-locator stream from ever seeing another event.
+          Log.reader.error("Failed to serialize locator for text-locator stream: \(error)")
+        }
       }
     }
   }

--- a/flutter_readium_platform_interface/CHANGELOG.md
+++ b/flutter_readium_platform_interface/CHANGELOG.md
@@ -11,6 +11,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   platform interface for distinguishing system media-control commands from
   ordinary playback state changes.
 
+### Fixed
+
+- **A single malformed reader-position event could stop updates for the rest of
+  the session.** `onTextLocatorChanged` and `onTimebasedPlayerStateChanged` threw
+  when a native event was `nil` or failed to parse, which breaks the stream for
+  any subscriber that treats the first error as fatal. Bad events are now logged
+  and skipped instead, so later position updates keep arriving.
+
 ## [0.4.0] - 2026-08-17
 
 ### Added

--- a/flutter_readium_platform_interface/CHANGELOG.md
+++ b/flutter_readium_platform_interface/CHANGELOG.md
@@ -10,14 +10,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ReadiumExternalPlaybackCommand` and `onExternalPlaybackCommand` in the shared
   platform interface for distinguishing system media-control commands from
   ordinary playback state changes.
+- `ReadiumTimebasedState.fromJsonString` / `fromJsonDynamic`, matching the
+  decoding pattern already used by `Locator` and `TextSearchResult`.
 
 ### Fixed
 
-- **A single malformed reader-position event could stop updates for the rest of
-  the session.** `onTextLocatorChanged` and `onTimebasedPlayerStateChanged` threw
-  when a native event was `nil` or failed to parse, which breaks the stream for
-  any subscriber that treats the first error as fatal. Bad events are now logged
-  and skipped instead, so later position updates keep arriving.
+- **Malformed native events no longer surface as uncaught async errors.**
+  `onTextLocatorChanged` and `onTimebasedPlayerStateChanged` threw when a native
+  event was `nil` or failed to parse. Later events still arrived, but each bad
+  one raised an unhandled error, and a subscriber using `cancelOnError: true`
+  lost its subscription. Such events are now logged and dropped.
+- `Locator.fromJsonString`, `TextSearchResult.fromJsonString`, and the new
+  `ReadiumTimebasedState.fromJsonString` no longer throw a `TypeError` on
+  well-formed but wrong-shaped JSON (a top-level array, say). They decoded
+  straight into `Map<String, dynamic>`, and the resulting `TypeError` is an
+  `Error`, so their `on Exception` guard never caught it. They now return `null`.
 
 ## [0.4.0] - 2026-08-17
 

--- a/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
+++ b/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
@@ -9,6 +9,59 @@ import 'flutter_readium_platform_interface.dart';
 
 final _log = ReadiumLog.tag('MethodChannel');
 
+/// Decodes a single text-locator channel event, or returns `null` to have the
+/// event dropped. Native sends `nil` when Locator JSON serialization fails
+/// (see `EPUBReaderView.swift` / `PDFReaderView.swift`), and `Locator.fromJson`
+/// itself returns `null` (already logged) when `href`/`type` are missing —
+/// one bad event must not kill the whole broadcast stream.
+Locator? _decodeTextLocatorEvent(final dynamic event) {
+  if (event is! String) {
+    _log.w('Skipping non-string text-locator event: $event');
+    return null;
+  }
+  try {
+    return Locator.fromJson(json.decode(event) as Map<String, dynamic>);
+  } on FormatException catch (e) {
+    _log.w('Skipping malformed text-locator JSON: $e');
+    return null;
+  } on TypeError catch (e) {
+    _log.w('Skipping text-locator JSON with unexpected shape: $e');
+    return null;
+  }
+}
+
+/// Decodes a single timebased-state channel event, or returns `null` to have
+/// the event dropped. `ReadiumTimebasedState.toJsonString()` returns `nil` on
+/// the native side when serialization fails, which must not kill the stream
+/// any more than a bad text-locator event should.
+ReadiumTimebasedState? _decodeTimebasedStateEvent(final dynamic event) {
+  if (event is! String) {
+    _log.w('Skipping non-string timebased-state event: $event');
+    return null;
+  }
+
+  final ReadiumTimebasedState state;
+  try {
+    state = ReadiumTimebasedState.fromJson(json.decode(event) as Map<String, dynamic>);
+  } on FormatException catch (e) {
+    _log.w('Skipping malformed timebased-state JSON: $e');
+    return null;
+  } on TypeError catch (e) {
+    _log.w('Skipping timebased-state JSON with unexpected shape: $e');
+    return null;
+  }
+
+  state.currentLocator?.locations?.let((locations) {
+    if (locations.position == null) {
+      debugPrint('Received timebased player state with currentLocator missing position: $state');
+    } else if (locations.position! <= 0) {
+      debugPrint('Received timebased player state with currentLocator invalid position: $state');
+    }
+  });
+
+  return state;
+}
+
 /// An implementation of [FlutterReadiumPlatform] that uses method channels.
 class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
   /// The method channel used to interact with the native platform.
@@ -52,7 +105,9 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
   Stream<Locator> get onTextLocatorChanged {
     _onTextLocatorChanged ??= textLocatorChannel
         .receiveBroadcastStream()
-        .map((dynamic event) => Locator.fromJson(json.decode(event) as Map<String, dynamic>)!)
+        .map(_decodeTextLocatorEvent)
+        .where((locator) => locator != null)
+        .cast<Locator>()
         .asBroadcastStream();
     return _onTextLocatorChanged!;
   }
@@ -60,19 +115,12 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
   /// Fires whenever the TimebasedNavigator changes state
   @override
   Stream<ReadiumTimebasedState> get onTimebasedPlayerStateChanged {
-    _onTimebasedPlayerStateChanged ??= timebasedStateChannel.receiveBroadcastStream().map((dynamic event) {
-      final state = ReadiumTimebasedState.fromJson(json.decode(event) as Map<String, dynamic>);
-
-      state.currentLocator?.locations?.let((locations) {
-        if (locations.position == null) {
-          debugPrint('Received timebased player state with currentLocator missing position: $state');
-        } else if (locations.position! <= 0) {
-          debugPrint('Received timebased player state with currentLocator invalid position: $state');
-        }
-      });
-
-      return state;
-    }).asBroadcastStream();
+    _onTimebasedPlayerStateChanged ??= timebasedStateChannel
+        .receiveBroadcastStream()
+        .map(_decodeTimebasedStateEvent)
+        .where((state) => state != null)
+        .cast<ReadiumTimebasedState>()
+        .asBroadcastStream();
 
     return _onTimebasedPlayerStateChanged!;
   }

--- a/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
+++ b/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
@@ -64,9 +64,9 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
   /// handshake completes (a race that can happen when the EPUB platform view
   /// initialises faster than the asynchronous channel setup).
   ///
-  /// Events that cannot be decoded are logged and dropped: native sends `nil`
-  /// when Locator serialization fails, and a decoded Locator missing `href` or
-  /// `type` yields `null`. Neither should reach consumers as a stream error.
+  /// Undecodable events are logged and dropped rather than raised on the stream.
+  /// Both platforms guard against emitting one, so this is defence against a
+  /// native regression — and against a Locator that decodes but fails validation.
   @override
   Stream<Locator> get onTextLocatorChanged {
     _onTextLocatorChanged ??= textLocatorChannel

--- a/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
+++ b/flutter_readium_platform_interface/lib/method_channel_flutter_readium.dart
@@ -9,48 +9,10 @@ import 'flutter_readium_platform_interface.dart';
 
 final _log = ReadiumLog.tag('MethodChannel');
 
-/// Decodes a single text-locator channel event, or returns `null` to have the
-/// event dropped. Native sends `nil` when Locator JSON serialization fails
-/// (see `EPUBReaderView.swift` / `PDFReaderView.swift`), and `Locator.fromJson`
-/// itself returns `null` (already logged) when `href`/`type` are missing —
-/// one bad event must not kill the whole broadcast stream.
-Locator? _decodeTextLocatorEvent(final dynamic event) {
-  if (event is! String) {
-    _log.w('Skipping non-string text-locator event: $event');
-    return null;
-  }
-  try {
-    return Locator.fromJson(json.decode(event) as Map<String, dynamic>);
-  } on FormatException catch (e) {
-    _log.w('Skipping malformed text-locator JSON: $e');
-    return null;
-  } on TypeError catch (e) {
-    _log.w('Skipping text-locator JSON with unexpected shape: $e');
-    return null;
-  }
-}
-
-/// Decodes a single timebased-state channel event, or returns `null` to have
-/// the event dropped. `ReadiumTimebasedState.toJsonString()` returns `nil` on
-/// the native side when serialization fails, which must not kill the stream
-/// any more than a bad text-locator event should.
-ReadiumTimebasedState? _decodeTimebasedStateEvent(final dynamic event) {
-  if (event is! String) {
-    _log.w('Skipping non-string timebased-state event: $event');
-    return null;
-  }
-
-  final ReadiumTimebasedState state;
-  try {
-    state = ReadiumTimebasedState.fromJson(json.decode(event) as Map<String, dynamic>);
-  } on FormatException catch (e) {
-    _log.w('Skipping malformed timebased-state JSON: $e');
-    return null;
-  } on TypeError catch (e) {
-    _log.w('Skipping timebased-state JSON with unexpected shape: $e');
-    return null;
-  }
-
+/// Pre-existing diagnostic, kept as-is: native has been seen sending a
+/// `currentLocator` with a missing or non-positive position. Logged rather than
+/// dropped, because the rest of the state is still usable.
+ReadiumTimebasedState _warnOnSuspiciousPosition(final ReadiumTimebasedState state) {
   state.currentLocator?.locations?.let((locations) {
     if (locations.position == null) {
       debugPrint('Received timebased player state with currentLocator missing position: $state');
@@ -101,25 +63,32 @@ class MethodChannelFlutterReadium extends FlutterReadiumPlatform {
   /// event is never dropped even if it fires before the Dart [onListen]
   /// handshake completes (a race that can happen when the EPUB platform view
   /// initialises faster than the asynchronous channel setup).
+  ///
+  /// Events that cannot be decoded are logged and dropped: native sends `nil`
+  /// when Locator serialization fails, and a decoded Locator missing `href` or
+  /// `type` yields `null`. Neither should reach consumers as a stream error.
   @override
   Stream<Locator> get onTextLocatorChanged {
     _onTextLocatorChanged ??= textLocatorChannel
         .receiveBroadcastStream()
-        .map(_decodeTextLocatorEvent)
+        .map(Locator.fromJsonDynamic)
         .where((locator) => locator != null)
         .cast<Locator>()
         .asBroadcastStream();
     return _onTextLocatorChanged!;
   }
 
-  /// Fires whenever the TimebasedNavigator changes state
+  /// Fires whenever the TimebasedNavigator changes state.
+  ///
+  /// Undecodable events are logged and dropped, as for [onTextLocatorChanged].
   @override
   Stream<ReadiumTimebasedState> get onTimebasedPlayerStateChanged {
     _onTimebasedPlayerStateChanged ??= timebasedStateChannel
         .receiveBroadcastStream()
-        .map(_decodeTimebasedStateEvent)
+        .map(ReadiumTimebasedState.fromJsonDynamic)
         .where((state) => state != null)
         .cast<ReadiumTimebasedState>()
+        .map(_warnOnSuspiciousPosition)
         .asBroadcastStream();
 
     return _onTimebasedPlayerStateChanged!;

--- a/flutter_readium_platform_interface/lib/src/shared/publication/dto/text_search_result.dart
+++ b/flutter_readium_platform_interface/lib/src/shared/publication/dto/text_search_result.dart
@@ -32,7 +32,14 @@ class TextSearchResult with Equatable implements JSONable {
 
   static TextSearchResult? fromJsonString(String jsonString) {
     try {
-      final Map<String, dynamic> json = JsonCodec().decode(jsonString);
+      // Decoded as `dynamic` on purpose; see Locator.fromJsonString.
+      final json = JsonCodec().decode(jsonString);
+      if (json is! Map<String, dynamic>) {
+        ReadiumLog.e(
+          'fromJsonString: Expected a JSON object for TextSearchResult, got ${json.runtimeType}: $jsonString',
+        );
+        return null;
+      }
       return TextSearchResult.fromJson(json);
     } on Exception catch (ex, st) {
       ReadiumLog.e(

--- a/flutter_readium_platform_interface/lib/src/shared/publication/locator.dart
+++ b/flutter_readium_platform_interface/lib/src/shared/publication/locator.dart
@@ -102,8 +102,7 @@ class Locator extends AdditionalProperties with Equatable implements JSONable {
   static Locator? fromJsonString(String jsonString) {
     try {
       // Decoded as `dynamic` on purpose: assigning straight to Map<String, dynamic>
-      // throws a TypeError for well-formed but wrong-shaped JSON (a top-level array,
-      // say), and TypeError is an Error, so the `on Exception` below cannot catch it.
+      // throws a TypeError for well-formed but wrong-shaped JSON (a top-level array).
       final json = JsonCodec().decode(jsonString);
       if (json is! Map<String, dynamic>) {
         ReadiumLog.e(
@@ -112,7 +111,7 @@ class Locator extends AdditionalProperties with Equatable implements JSONable {
         return null;
       }
       return Locator.fromJson(json);
-    } on Exception catch (ex, st) {
+    } on Object catch (ex, st) {
       ReadiumLog.e(
         'fromJsonString: Failed to parse Locator from json: $jsonString',
         stackTrace: st,

--- a/flutter_readium_platform_interface/lib/src/shared/publication/locator.dart
+++ b/flutter_readium_platform_interface/lib/src/shared/publication/locator.dart
@@ -101,7 +101,16 @@ class Locator extends AdditionalProperties with Equatable implements JSONable {
 
   static Locator? fromJsonString(String jsonString) {
     try {
-      final Map<String, dynamic> json = JsonCodec().decode(jsonString);
+      // Decoded as `dynamic` on purpose: assigning straight to Map<String, dynamic>
+      // throws a TypeError for well-formed but wrong-shaped JSON (a top-level array,
+      // say), and TypeError is an Error, so the `on Exception` below cannot catch it.
+      final json = JsonCodec().decode(jsonString);
+      if (json is! Map<String, dynamic>) {
+        ReadiumLog.e(
+          'fromJsonString: Expected a JSON object for Locator, got ${json.runtimeType}: $jsonString',
+        );
+        return null;
+      }
       return Locator.fromJson(json);
     } on Exception catch (ex, st) {
       ReadiumLog.e(

--- a/flutter_readium_platform_interface/lib/src/timebased_state.dart
+++ b/flutter_readium_platform_interface/lib/src/timebased_state.dart
@@ -1,9 +1,12 @@
+import 'dart:convert' show JsonCodec;
+
 import 'package:meta/meta.dart';
 
 import 'enums.dart';
 import 'shared/publication/locator.dart';
 import 'utils/constants.dart';
 import 'utils/jsonable.dart';
+import 'utils/readium_log.dart';
 
 @immutable
 class ReadiumTimebasedState implements JSONable {
@@ -73,6 +76,42 @@ class ReadiumTimebasedState implements JSONable {
       totalDuration: totalDuration != null ? Duration(milliseconds: totalDuration) : null,
       currentLocator: currentLocator,
     );
+  }
+
+  static ReadiumTimebasedState? fromJsonString(String jsonString) {
+    try {
+      // Decoded as `dynamic` on purpose; see Locator.fromJsonString.
+      final json = JsonCodec().decode(jsonString);
+      if (json is! Map<String, dynamic>) {
+        ReadiumLog.e(
+          'fromJsonString: Expected a JSON object for ReadiumTimebasedState, '
+          'got ${json.runtimeType}: $jsonString',
+        );
+        return null;
+      }
+      return ReadiumTimebasedState.fromJson(json);
+    } on Exception catch (ex, st) {
+      ReadiumLog.e(
+        'fromJsonString: Failed to parse ReadiumTimebasedState from json: $jsonString',
+        stackTrace: st,
+      );
+    }
+    return null;
+  }
+
+  static ReadiumTimebasedState? fromJsonDynamic(dynamic json) {
+    if (json == null) {
+      return null;
+    } else if (json is String) {
+      return fromJsonString(json);
+    } else if (json is Map<String, dynamic>) {
+      return ReadiumTimebasedState.fromJson(json);
+    }
+
+    ReadiumLog.e(
+      'ReadiumTimebasedState.fromJsonDynamic: Unsupported json type: ${json.runtimeType}',
+    );
+    return null;
   }
 
   @override

--- a/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
+++ b/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
@@ -75,7 +75,8 @@ void main() {
       expect(events.single.type, testLocator.type);
     }
 
-    // Native `try? finalLocator.jsonString()` sends nil on serialization failure.
+    // Both platforms guard against emitting nil; this pins the Dart side's
+    // behaviour if that ever regresses.
     test('a nil event is dropped', () => expectSurvives(null));
 
     test('malformed JSON is dropped', () => expectSurvives('not valid json {'));
@@ -110,7 +111,6 @@ void main() {
       expect(events.single.currentLocator?.href, testState.currentLocator?.href);
     }
 
-    // Native `ReadiumTimebasedState.toJsonString()` returns nil on failure.
     test('a nil event is dropped', () => expectSurvives(null));
 
     test('malformed JSON is dropped', () => expectSurvives('not valid json {'));

--- a/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
+++ b/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
@@ -8,63 +9,129 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late MethodChannelFlutterReadium methodChannelReadium;
+  final subscriptions = <StreamSubscription<dynamic>>[];
+
+  setUp(() {
+    methodChannelReadium = MethodChannelFlutterReadium();
+  });
+
+  tearDown(() async {
+    for (final subscription in subscriptions) {
+      await subscription.cancel();
+    }
+    subscriptions.clear();
+  });
+
+  /// Pushes a single event through the *real* EventChannel plumbing (the same
+  /// path native `sendEvent` calls use), mirroring how the existing
+  /// `onTextLocatorChanged emits the locator` test drives the channel.
+  Future<void> emit(final EventChannel channel, final dynamic value) =>
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        channel.name,
+        channel.codec.encodeSuccessEnvelope(value),
+        (_) {},
+      );
+
+  /// Sends [badEvent], then a known-good event, and asserts the bad one was
+  /// dropped without surfacing as a stream error while the good one still
+  /// arrived. Uses an ordinary listener with `onError`, which is how consumers
+  /// actually subscribe.
+  Future<List<T>> expectDroppedNotRaised<T>({
+    required final Stream<T> stream,
+    required final EventChannel channel,
+    required final dynamic badEvent,
+    required final dynamic goodEvent,
+  }) async {
+    final events = <T>[];
+    final errors = <Object>[];
+    subscriptions.add(stream.listen(events.add, onError: errors.add));
+
+    await emit(channel, badEvent);
+    await Future<void>.delayed(Duration.zero);
+    await emit(channel, goodEvent);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(errors, isEmpty, reason: 'the bad event must be dropped, not surfaced as a stream error');
+    expect(events, hasLength(1), reason: 'the valid event sent after the bad one must still arrive');
+    return events;
+  }
+
   group('onTextLocatorChanged resilience to bad native events', () {
-    late MethodChannelFlutterReadium methodChannelReadium;
-    final testTextLocator = Locator(
+    final testLocator = Locator(
       href: 'chapter1.html',
       type: 'text/xhtml',
       locations: Locations(cssSelector: '#loc1'),
     );
 
-    setUp(() {
-      methodChannelReadium = MethodChannelFlutterReadium();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-        MethodChannel(methodChannelReadium.textLocatorChannel.name),
-        (methodCall) async => null,
+    Future<void> expectSurvives(final dynamic badEvent) async {
+      final events = await expectDroppedNotRaised(
+        stream: methodChannelReadium.onTextLocatorChanged,
+        channel: methodChannelReadium.textLocatorChannel,
+        badEvent: badEvent,
+        goodEvent: jsonEncode(testLocator.toJson()),
       );
-    });
-
-    /// Pushes a single event through the *real* EventChannel plumbing (the
-    /// same path native `sendEvent` calls use), mirroring how the existing
-    /// `onTextLocatorChanged emits the locator` test drives the channel.
-    Future<void> emit(dynamic value) =>
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-          methodChannelReadium.textLocatorChannel.name,
-          methodChannelReadium.textLocatorChannel.codec.encodeSuccessEnvelope(value),
-          (_) {},
-        );
-
-    /// Listens with `cancelOnError: true` — the one subscription style that
-    /// actually drops a broadcast stream on the first unhandled error, so a
-    /// pass here proves the bad event never reaches the stream as an error.
-    Future<void> expectSurvives(dynamic badEvent) async {
-      final events = <Locator>[];
-      final errors = <Object>[];
-      methodChannelReadium.onTextLocatorChanged.listen(
-        events.add,
-        onError: errors.add,
-        cancelOnError: true,
-      );
-
-      await emit(badEvent);
-      await Future<void>.delayed(Duration.zero);
-      await emit(jsonEncode(testTextLocator.toJson()));
-      await Future<void>.delayed(Duration.zero);
-
-      expect(errors, isEmpty, reason: 'bad event must be dropped, not surfaced as a stream error');
-      expect(events, hasLength(1), reason: 'the valid event sent after the bad one must still arrive');
-      expect(events.single.href, testTextLocator.href);
-      expect(events.single.type, testTextLocator.type);
+      expect(events.single.href, testLocator.href);
+      expect(events.single.type, testLocator.type);
     }
 
     // Native `try? finalLocator.jsonString()` sends nil on serialization failure.
-    test('a nil event is dropped and does not kill the stream', () => expectSurvives(null));
+    test('a nil event is dropped', () => expectSurvives(null));
 
-    test('malformed JSON is dropped and does not kill the stream', () => expectSurvives('not valid json {'));
+    test('malformed JSON is dropped', () => expectSurvives('not valid json {'));
+
+    test('a top-level JSON array is dropped', () => expectSurvives('[1,2,3]'));
 
     test(
-      'a locator JSON missing "type" is dropped and does not kill the stream',
+      'a locator JSON missing "type" is dropped',
       () => expectSurvives(jsonEncode({'href': 'chapter1.html'})),
     );
+  });
+
+  group('onTimebasedPlayerStateChanged resilience to bad native events', () {
+    final testState = ReadiumTimebasedState(
+      state: TimebasedState.playing,
+      currentOffset: const Duration(seconds: 12),
+      currentLocator: Locator(
+        href: 'track1.mp3',
+        type: 'audio/mpeg',
+        locations: Locations(position: 1, progression: 0.5, totalProgression: 0.25),
+      ),
+    );
+
+    Future<void> expectSurvives(final dynamic badEvent) async {
+      final events = await expectDroppedNotRaised(
+        stream: methodChannelReadium.onTimebasedPlayerStateChanged,
+        channel: methodChannelReadium.timebasedStateChannel,
+        badEvent: badEvent,
+        goodEvent: jsonEncode(testState.toJson()),
+      );
+      expect(events.single.state, testState.state);
+      expect(events.single.currentLocator?.href, testState.currentLocator?.href);
+    }
+
+    // Native `ReadiumTimebasedState.toJsonString()` returns nil on failure.
+    test('a nil event is dropped', () => expectSurvives(null));
+
+    test('malformed JSON is dropped', () => expectSurvives('not valid json {'));
+
+    test('a top-level JSON array is dropped', () => expectSurvives('[1,2,3]'));
+  });
+
+  group('fromJsonString rejects wrong-shaped JSON instead of throwing', () {
+    // Regression: these decoded straight into Map<String, dynamic>, so a
+    // top-level array threw a TypeError that `on Exception` could not catch.
+    test('Locator', () {
+      expect(Locator.fromJsonString('[1,2,3]'), isNull);
+      expect(Locator.fromJsonString('"just a string"'), isNull);
+    });
+
+    test('ReadiumTimebasedState', () {
+      expect(ReadiumTimebasedState.fromJsonString('[1,2,3]'), isNull);
+    });
+
+    test('TextSearchResult', () {
+      expect(TextSearchResult.fromJsonString('[1,2,3]'), isNull);
+    });
   });
 }

--- a/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
+++ b/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_readium_platform_interface/method_channel_flutter_readium.dart';
+import 'package:flutter_readium_platform_interface/src/index.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('onTextLocatorChanged resilience to bad native events', () {
+    late MethodChannelFlutterReadium methodChannelReadium;
+    final testTextLocator = Locator(
+      href: 'chapter1.html',
+      type: 'text/xhtml',
+      locations: Locations(cssSelector: '#loc1'),
+    );
+
+    setUp(() {
+      methodChannelReadium = MethodChannelFlutterReadium();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        MethodChannel(methodChannelReadium.textLocatorChannel.name),
+        (methodCall) async => null,
+      );
+    });
+
+    /// Pushes a single event through the *real* EventChannel plumbing (the
+    /// same path native `sendEvent` calls use), mirroring how the existing
+    /// `onTextLocatorChanged emits the locator` test drives the channel.
+    Future<void> emit(dynamic value) => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          methodChannelReadium.textLocatorChannel.name,
+          methodChannelReadium.textLocatorChannel.codec.encodeSuccessEnvelope(value),
+          (_) {},
+        );
+
+    /// Listens with `cancelOnError: true` — the one subscription style that
+    /// actually drops a broadcast stream on the first unhandled error, so a
+    /// pass here proves the bad event never reaches the stream as an error.
+    Future<void> expectSurvives(dynamic badEvent) async {
+      final events = <Locator>[];
+      final errors = <Object>[];
+      methodChannelReadium.onTextLocatorChanged.listen(
+        events.add,
+        onError: errors.add,
+        cancelOnError: true,
+      );
+
+      await emit(badEvent);
+      await Future<void>.delayed(Duration.zero);
+      await emit(jsonEncode(testTextLocator.toJson()));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(errors, isEmpty, reason: 'bad event must be dropped, not surfaced as a stream error');
+      expect(events, [testTextLocator], reason: 'the valid event sent after the bad one must still arrive');
+    }
+
+    // Native `try? finalLocator.jsonString()` sends nil on serialization failure.
+    test('a nil event is dropped and does not kill the stream', () => expectSurvives(null));
+
+    test('malformed JSON is dropped and does not kill the stream', () => expectSurvives('not valid json {'));
+
+    test(
+      'a locator JSON missing "type" is dropped and does not kill the stream',
+      () => expectSurvives(jsonEncode({'href': 'chapter1.html'})),
+    );
+  });
+}

--- a/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
+++ b/flutter_readium_platform_interface/test/method_channel_stream_resilience_test.dart
@@ -27,8 +27,8 @@ void main() {
     /// Pushes a single event through the *real* EventChannel plumbing (the
     /// same path native `sendEvent` calls use), mirroring how the existing
     /// `onTextLocatorChanged emits the locator` test drives the channel.
-    Future<void> emit(dynamic value) => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .handlePlatformMessage(
+    Future<void> emit(dynamic value) =>
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
           methodChannelReadium.textLocatorChannel.name,
           methodChannelReadium.textLocatorChannel.codec.encodeSuccessEnvelope(value),
           (_) {},
@@ -52,7 +52,9 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       expect(errors, isEmpty, reason: 'bad event must be dropped, not surfaced as a stream error');
-      expect(events, [testTextLocator], reason: 'the valid event sent after the bad one must still arrive');
+      expect(events, hasLength(1), reason: 'the valid event sent after the bad one must still arrive');
+      expect(events.single.href, testTextLocator.href);
+      expect(events.single.type, testTextLocator.type);
     }
 
     // Native `try? finalLocator.jsonString()` sends nil on serialization failure.


### PR DESCRIPTION
Malformed or `nil` events on the text-locator / timebased-state channels throw inside the stream `.map`, and the native side quietly discards the serialization failure that caused it.

## Scope, after review

An earlier revision of this PR claimed a bad event killed the stream permanently. **That is wrong and has been removed.** For the record, what actually happens:

- A Swift `nil` becomes a null EventChannel event. It does not end the channel — that needs `FlutterEndOfEventStream`.
- A throw inside `Stream.map` emits a stream *error* and keeps listening.
- `cancelOnError: true` cancels that one subscription by design; it does not kill the shared broadcast stream.

**There is no production evidence of this firing.** I searched Sentry (org `notalib-eu`, 90 days): zero issues with a culprit in `method_channel_flutter_readium.dart`, zero `FormatException`. The old `!` would have surfaced as "Null check operator used on a null value" from that file, and it is not among the top 25 `TypeError` issues.

So this is **hardening plus a genuine root-cause fix**, not a regression fix. The real benefits:

1. Malformed events no longer surface as uncaught async errors.
2. iOS no longer discards *why* serialization failed.
3. `fromJsonString` no longer throws an uncatchable `TypeError` — see below. This one is a real latent bug on a path unrelated to these streams.

## Changes

**Dart — reuse, not reinvention.** The first revision added two private decoders. They duplicated `Locator.fromJsonDynamic`, which is the house pattern (used in 8+ places) and already handles nil, a JSON string, a decoded map, and a Locator failing validation. Both are gone; the streams call the shared helpers.

**Root-cause fix.** Reusing them exposed a gap: `fromJsonString` decoded straight into `Map<String, dynamic>`, so well-formed but wrong-shaped JSON (a top-level array) threw a `TypeError`. `TypeError` is an `Error`, so the surrounding `on Exception` never caught it. Fixed in `Locator`, `TextSearchResult`, and the new `ReadiumTimebasedState.fromJsonString`, so every caller benefits — including the search-results path at `method_channel_flutter_readium.dart:344`, which has nothing to do with these streams.

**Added** `ReadiumTimebasedState.fromJsonString` / `fromJsonDynamic`, matching `Locator` and `TextSearchResult`.

**Swift.** `try?` → `do`/`catch` with logging at the two reader call sites, plus the two `ReadiumTimebasedState.toJsonString()` sites in `FlutterReadiumPlugin.swift` (non-throwing but `String?`-returning, same nil-forwarding shape).

## Verification

- `flutter test` in `flutter_readium_platform_interface`: **209/209**, with 10 tests here — both streams now, not just text-locator. Subscriptions are captured and cancelled in `tearDown`, and listeners use an ordinary `onError` rather than `cancelOnError: true`.
- **Confirmed red before the fix**: reverting the four `lib/` files to `main` fails all 7 stream tests, e.g. `Expected: empty Actual: [_TypeError:type 'List<dynamic>' is not a subtype of type 'Map<String, dynamic>' in type cast]`.
- `bin/format` clean · `bin/analyze` no issues across all 3 packages.
- iOS build and Android/web suites were verified on the earlier revision; **the Swift files are unchanged since**, but I have not re-run them against this revision. The change since then is Dart-only.

## Known sharp edge, deliberately not touched

`TextSearchResult.fromJson` still does `Locator.fromJsonDynamic(...)!` and throws `ArgumentError` on null input. Both are `Error`s that `fromJsonString` cannot catch, so a search result missing its `locator` still throws. Out of scope here — flag it if you want it in this PR.

Also carries a 2-line `example/pubspec.lock` bump (0.3.3 → 0.4.0) that `pub get` regenerated because `main` is at 0.4.0. Unrelated to this change; say the word and I will drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
