### PR TITLE
fix(scripts): repair bin/unit_tests, and make Android CI hangs diagnosable

### DIFF
--- a/.github/workflows/integration-test-android.yml
+++ b/.github/workflows/integration-test-android.yml
@@ -109,11 +109,7 @@ jobs:
           # when it ends, so a later `if: failure()` step (as on iOS) can't reach it.
           script: |
             adb logcat -c || true
-            # `timeout` keeps the test run inside the job's 30-minute budget so the
-            # capture below can still run. Without it a hang is killed by the
-            # job-level timeout-minutes, which tears down the whole process tree —
-            # the `||` never fires and the failure is an opaque cancellation with no
-            # logcat. API 24 has hit this; see the run linked in the PR.
+            # Bounded so a hang can't trip timeout-minutes, which would kill the capture below.
             timeout 18m flutter test integration_test/plugin_integration_test.dart --dart-define=READIUM_TEST_SKIP_LOGS=true || (adb logcat -d -v threadtime > "$GITHUB_WORKSPACE/android-logcat-api${{ matrix.api-level }}.txt" 2>&1; exit 1)
 
       - name: Upload Android diagnostics

--- a/.github/workflows/integration-test-android.yml
+++ b/.github/workflows/integration-test-android.yml
@@ -109,7 +109,12 @@ jobs:
           # when it ends, so a later `if: failure()` step (as on iOS) can't reach it.
           script: |
             adb logcat -c || true
-            flutter test integration_test/plugin_integration_test.dart --dart-define=READIUM_TEST_SKIP_LOGS=true || (adb logcat -d -v threadtime > "$GITHUB_WORKSPACE/android-logcat-api${{ matrix.api-level }}.txt" 2>&1; exit 1)
+            # `timeout` keeps the test run inside the job's 30-minute budget so the
+            # capture below can still run. Without it a hang is killed by the
+            # job-level timeout-minutes, which tears down the whole process tree —
+            # the `||` never fires and the failure is an opaque cancellation with no
+            # logcat. API 24 has hit this; see the run linked in the PR.
+            timeout 18m flutter test integration_test/plugin_integration_test.dart --dart-define=READIUM_TEST_SKIP_LOGS=true || (adb logcat -d -v threadtime > "$GITHUB_WORKSPACE/android-logcat-api${{ matrix.api-level }}.txt" 2>&1; exit 1)
 
       - name: Upload Android diagnostics
         if: failure()

--- a/bin/format
+++ b/bin/format
@@ -6,14 +6,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
 # (which includes flutter_lints/flutter.yaml for the page_width: 120 setting).
 # Without it, the formatter falls back to 80-char page width and produces
 # different output than CI (which always runs pub get before dart format).
-#
-# Each pub get cd's into its package rather than using --directory: flutter_tools
-# resolves the *current project* from the working directory, so from $REPO_ROOT it
-# cannot see a package's own pubspec flutter config. For the example app that means
-# its "enable-swift-package-manager: false" override is ignored, and the resulting
-# SPM-enabled resolution leaves the ephemeral FlutterGeneratedPluginSwiftPackage
-# declaring iOS 13.0 while depending on packages that require 15.0 — which breaks
-# the next "bin/unit_tests ios". See test_ios() in bin/unit_tests.
+# cd, not --directory: flutter_tools reads pubspec flutter config from the cwd.
 
 echo "Formatting flutter_readium_platform_interface..."
 ( cd "$REPO_ROOT/flutter_readium_platform_interface" && flutter pub get > /dev/null )

--- a/bin/format
+++ b/bin/format
@@ -6,15 +6,23 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
 # (which includes flutter_lints/flutter.yaml for the page_width: 120 setting).
 # Without it, the formatter falls back to 80-char page width and produces
 # different output than CI (which always runs pub get before dart format).
+#
+# Each pub get cd's into its package rather than using --directory: flutter_tools
+# resolves the *current project* from the working directory, so from $REPO_ROOT it
+# cannot see a package's own pubspec flutter config. For the example app that means
+# its "enable-swift-package-manager: false" override is ignored, and the resulting
+# SPM-enabled resolution leaves the ephemeral FlutterGeneratedPluginSwiftPackage
+# declaring iOS 13.0 while depending on packages that require 15.0 — which breaks
+# the next "bin/unit_tests ios". See test_ios() in bin/unit_tests.
 
 echo "Formatting flutter_readium_platform_interface..."
-flutter pub get --directory "$REPO_ROOT/flutter_readium_platform_interface" > /dev/null
+( cd "$REPO_ROOT/flutter_readium_platform_interface" && flutter pub get > /dev/null )
 dart format --set-exit-if-changed "$REPO_ROOT/flutter_readium_platform_interface"
 
 echo "Formatting flutter_readium..."
-flutter pub get --directory "$REPO_ROOT/flutter_readium" > /dev/null
+( cd "$REPO_ROOT/flutter_readium" && flutter pub get > /dev/null )
 dart format --set-exit-if-changed "$REPO_ROOT/flutter_readium"
 
 echo "Formatting example app..."
-flutter pub get --directory "$REPO_ROOT/flutter_readium/example" > /dev/null
+( cd "$REPO_ROOT/flutter_readium/example" && flutter pub get > /dev/null )
 dart format --set-exit-if-changed "$REPO_ROOT/flutter_readium/example"

--- a/bin/unit_tests
+++ b/bin/unit_tests
@@ -35,13 +35,7 @@ function test_ios() {
   local EXAMPLE_DIR="$REPO_ROOT/flutter_readium/example"
   local IOS_DIR="$EXAMPLE_DIR/ios"
 
-  # cd rather than "pub get --directory": flutter_tools resolves the *current
-  # project* (and its pubspec's "enable-swift-package-manager: false" override)
-  # from the working directory, not from --directory. Run from $REPO_ROOT and
-  # it silently falls back to the (default-on) global Swift Package Manager
-  # setting, regenerating FlutterGeneratedPluginSwiftPackage with real plugin
-  # dependencies whose deployment-target bump never runs outside "flutter
-  # build ios" — leaving a stale platform mismatch the next xcodebuild sees.
+  # cd, not --directory: --directory loses this pubspec's SPM override.
   ( cd "$EXAMPLE_DIR" && flutter pub get > /dev/null )
 
   # The CocoaPods podhelper needs Flutter's generated iOS config (and the
@@ -85,11 +79,9 @@ function test_android() {
 
   if [ ! -f "$EXAMPLE_DIR/android/gradlew" ]; then
     echo "Gradle wrapper not found — generating via 'flutter build apk --config-only'..."
-    # cd rather than "pub get --directory" — see test_ios() for why: run from
-    # $REPO_ROOT, flutter_tools can't see this project's pubspec overrides.
+    # cd, not --directory (see test_ios).
     ( cd "$EXAMPLE_DIR" && flutter pub get > /dev/null )
-    # "flutter build apk" has no --project-directory flag; cd into place instead
-    # (same idiom test_ios() already uses for "flutter build ios --config-only").
+    # flutter build apk has no --project-directory flag.
     ( cd "$EXAMPLE_DIR" && flutter build apk --config-only )
   fi
 

--- a/bin/unit_tests
+++ b/bin/unit_tests
@@ -35,7 +35,14 @@ function test_ios() {
   local EXAMPLE_DIR="$REPO_ROOT/flutter_readium/example"
   local IOS_DIR="$EXAMPLE_DIR/ios"
 
-  flutter pub get --directory "$EXAMPLE_DIR" > /dev/null
+  # cd rather than "pub get --directory": flutter_tools resolves the *current
+  # project* (and its pubspec's "enable-swift-package-manager: false" override)
+  # from the working directory, not from --directory. Run from $REPO_ROOT and
+  # it silently falls back to the (default-on) global Swift Package Manager
+  # setting, regenerating FlutterGeneratedPluginSwiftPackage with real plugin
+  # dependencies whose deployment-target bump never runs outside "flutter
+  # build ios" — leaving a stale platform mismatch the next xcodebuild sees.
+  ( cd "$EXAMPLE_DIR" && flutter pub get > /dev/null )
 
   # The CocoaPods podhelper needs Flutter's generated iOS config (and the
   # ephemeral SPM packages the plugin depends on); --config-only writes them
@@ -78,8 +85,12 @@ function test_android() {
 
   if [ ! -f "$EXAMPLE_DIR/android/gradlew" ]; then
     echo "Gradle wrapper not found — generating via 'flutter build apk --config-only'..."
-    flutter pub get --directory "$EXAMPLE_DIR" > /dev/null
-    flutter build apk --config-only --project-directory "$EXAMPLE_DIR"
+    # cd rather than "pub get --directory" — see test_ios() for why: run from
+    # $REPO_ROOT, flutter_tools can't see this project's pubspec overrides.
+    ( cd "$EXAMPLE_DIR" && flutter pub get > /dev/null )
+    # "flutter build apk" has no --project-directory flag; cd into place instead
+    # (same idiom test_ios() already uses for "flutter build ios --config-only").
+    ( cd "$EXAMPLE_DIR" && flutter build apk --config-only )
   fi
 
   cd "$EXAMPLE_DIR/android" || exit 1

--- a/flutter_readium/example/pubspec.lock
+++ b/flutter_readium/example/pubspec.lock
@@ -177,14 +177,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.3"
+    version: "0.4.0"
   flutter_readium_platform_interface:
     dependency: "direct overridden"
     description:
       path: "../../flutter_readium_platform_interface"
       relative: true
     source: path
-    version: "0.3.3"
+    version: "0.4.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter


### PR DESCRIPTION
Two dev-tooling fixes plus one CI diagnostic. No production code touched.

## 1. `bin/unit_tests` was broken on every fresh checkout

`flutter build apk --config-only --project-directory "$EXAMPLE_DIR"` — `--project-directory` is not a valid flag in the pinned Flutter 3.44.8. That branch only runs when `example/android/gradlew` is missing, and `gradlew` is gitignored, so it fires for everyone cloning fresh.

## 2. The iOS leg — subtler root cause

`bin/unit_tests ios` failed with:

```
error: The package product 'flutter-readium' requires minimum platform version 15.0
for the iOS platform, but this target supports 13.0
(in target 'FlutterGeneratedPluginSwiftPackage')
```

The `Podfile` and `project.pbxproj` are both correct at 15.0. The actual cause is that **`flutter pub get --directory X` resolves the current project from the process working directory, not from `--directory`.** Run from the repo root, the example's `enable-swift-package-manager: false` override is invisible, so Flutter's default-on SPM kicks in and rewrites the ephemeral `FlutterGeneratedPluginSwiftPackage` with real plugin dependencies while leaving its declared platform at `.iOS("13.0")`.

Fix: `cd` into the package instead of using `--directory`.

## 3. `bin/format` had the same idiom — and re-broke the iOS leg

Three call sites in `bin/format`. It does not fail itself, but it poisons the ephemeral package for the *next* `bin/unit_tests ios`:

```
BEFORE bin/format:  dependencies: []
AFTER  bin/format:  .package(name: "flutter_readium", ...)   # requires 15.0
                    platforms: [.iOS("13.0")]                # unchanged
```

Since the documented pre-PR sequence is `bin/format` then tests, every contributor would have re-broken iOS immediately after it was fixed. The corrected `bin/format` also self-heals an already-corrupted package.

## 4. CI: Android integration-test hangs are undiagnosable

The step's `|| (adb logcat -d ...)` fallback only fires when `flutter test` exits. A hang instead hits the job-level `timeout-minutes: 30`, which kills the whole process tree — no logcat, opaque cancellation.

API 24 has hit this ([run 32471201110](https://github.com/Notalib/flutter_readium/actions/runs/32471201110)): both legs build in ~230s, then API 36 installs the APK in **966ms** while API 24 goes silent for **~20 minutes** and is cancelled mid-install. Identical emulator config; only `api-level` differs.

`timeout 18m` makes the command exit inside the job budget so the existing capture and artifact upload actually run. **This does not fix the hang** — it makes the next occurrence diagnosable. The timeout was deliberately not raised, since that would bury the regression.

## Verification

`bin/unit_tests` web **257/257** · android **BUILD SUCCESSFUL** · ios **exit 0, 26 tests** — the iOS run performed *after* `bin/format`, which is the sequence that previously failed. `bin/analyze` no issues across all 3 packages. Workflow YAML parses.

The CI change is **unverified** — it cannot be exercised locally and will only be proven by the next hang.

No CHANGELOG entry: tooling only, nothing a consumer upgrading would notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)