### PR TITLE
chore(ios): migrate example app to UIScene lifecycle

### DIFF
--- a/flutter_readium/example/ios/Runner/AppDelegate.swift
+++ b/flutter_readium/example/ios/Runner/AppDelegate.swift
@@ -3,15 +3,18 @@ import UIKit
 import flutter_readium
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
-  
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+  }
+
   @objc func onCustomEditingAction() {
     debugPrint("AppDelegate.onCustomEditingAction")
     // TODO: Test if this works, it should trigger a custom action response.

--- a/flutter_readium/example/ios/Runner/Info.plist
+++ b/flutter_readium/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,34 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,14 +71,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-  <key>NSAppTransportSecurity</key>
-  <dict>
-    <key>NSAllowsArbitraryLoads</key>
-    <true/>
-  </dict>
 </dict>
 </plist>

--- a/flutter_readium/example/lib/pages/bookshelf.page.dart
+++ b/flutter_readium/example/lib/pages/bookshelf.page.dart
@@ -151,6 +151,8 @@ class BookshelfPageState extends State<BookshelfPage> {
     body: SafeArea(
       child: _isLoading
           ? Center(child: CircularProgressIndicator())
+          : _testPublications.isEmpty
+          ? _buildEmptyState(context)
           : Column(
               children: [
                 Expanded(
@@ -177,6 +179,36 @@ class BookshelfPageState extends State<BookshelfPage> {
                 // _buildAddBookCard(context),
               ],
             ),
+    ),
+  );
+
+  /// Test fixtures are generated and gitignored, so an empty shelf almost always
+  /// means `bin/fetch_test_resources` has not been run in this checkout.
+  Widget _buildEmptyState(final BuildContext context) => Center(
+    key: const ValueKey('bookshelf_empty_state'),
+    child: Padding(
+      padding: const EdgeInsets.all(24.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.library_books_outlined,
+            size: 64,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+          const SizedBox(height: 16),
+          Text('No publications found', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            'Test fixtures are generated, not committed. Run bin/fetch_test_resources '
+            'from the repo root, then restart the app.',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
     ),
   );
 


### PR DESCRIPTION
UIScene lifecycle is required on iOS 27+. `flutter_tools` hard-fails to launch an unmigrated app there ([`ios/devices.dart:878`](https://github.com/flutter/flutter/blob/main/packages/flutter_tools/lib/src/ios/devices.dart#L878)), so this is a launch blocker, not just the CLI warning.

Ran Flutter's own UIScene migrator rather than hand-editing: stripped `AppDelegate.swift` to the stock template, let the tool migrate, then re-added `import flutter_readium` and `onCustomEditingAction()`. The plist key is therefore written by Flutter's `plutil`-backed parser.

- `Info.plist` — adds `UIApplicationSceneManifest`, pointing at `FlutterSceneDelegate`.
- `AppDelegate.swift` — conforms to `FlutterImplicitEngineDelegate`; plugin registration moves to `didInitializeImplicitFlutterEngine`.

No `SceneDelegate.swift`: the migrator uses `FlutterSceneDelegate` directly, which avoids a `project.pbxproj` edit for no behaviour difference.

Plugin sources needed no change — no `UIApplication.shared`, `keyWindow`, `.windows`, or app-lifecycle delegate hooks anywhere in `flutter_readium/ios/`.

Second commit is unrelated but small: the example bookshelf now explains that an empty shelf means `bin/fetch_test_resources` hasn't been run, instead of rendering blank.

## Verification

On an iPhone 17 Pro simulator:

- Migrator printed `Finished migration to UIScene lifecycle.`
- Clean re-run of `flutter build ios --config-only` — no UIScene warnings.
- App launches; bookshelf loads; opening Moby Dick renders the EPUB in the native webview (checked via `simctl io screenshot`, since webviews don't appear in marionette captures).
- Empty state confirmed by moving fixtures aside and wiping app storage, then restored.
- `bin/format` and `bin/analyze` clean.

No CHANGELOG entry — both changes are example-app only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)