### PR TITLE
fix(android): migrate to built-in Kotlin

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **Android builds warned that `flutter_readium` still applied the Kotlin Gradle Plugin.**
+  The Android source layout and example now support AGP's built-in Kotlin, and
+  `wakelock_plus` is constrained to a compatible release.
+
 ## [0.4.2] - 2026-08-28
 
 ### Fixed

--- a/flutter_readium/android/CLAUDE.md
+++ b/flutter_readium/android/CLAUDE.md
@@ -17,4 +17,5 @@ Thin wrapper over [kotlin-toolkit](https://github.com/readium/kotlin-toolkit/); 
 
 ## Toolchain
 
-`minSdkVersion 24`, `compileSdk 36`, Kotlin 2.3.21, AGP 8.13.2, Java 18 source/target.
+`minSdkVersion 24`, `compileSdk 36`, Kotlin 2.3.21, Java 18 source/target.
+The plugin fallback uses AGP 8.13.2; the example validates AGP 9.3.0 with Gradle 9.5.

--- a/flutter_readium/android/build.gradle
+++ b/flutter_readium/android/build.gradle
@@ -52,7 +52,6 @@ android {
   compileSdkVersion 36
 
   sourceSets {
-    main.java.srcDirs += 'src/main/kotlin'
     main.res.srcDirs += 'src/main/res'
   }
   defaultConfig {

--- a/flutter_readium/android/gradle.properties
+++ b/flutter_readium/android/gradle.properties
@@ -1,5 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.newDsl=false
-android.builtInKotlin=false
-

--- a/flutter_readium/example/android/app/build.gradle.kts
+++ b/flutter_readium/example/android/app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("com.android.application")
-  // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins
+  // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
   id("dev.flutter.flutter-gradle-plugin")
 }
 

--- a/flutter_readium/example/android/gradle.properties
+++ b/flutter_readium/example/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 # This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
+android.builtInKotlin=true
 # This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false

--- a/flutter_readium/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_readium/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip

--- a/flutter_readium/example/android/settings.gradle.kts
+++ b/flutter_readium/example/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
   id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-  id("com.android.application") version "8.13.2" apply false
+  id("com.android.application") version "9.3.0" apply false
   id("org.jetbrains.kotlin.android") version "2.3.21" apply false
   id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
 }

--- a/flutter_readium/pubspec.yaml
+++ b/flutter_readium/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   flutter_readium_platform_interface: ^0.4.2
-  wakelock_plus: ^1.6.0
+  wakelock_plus: ^1.7.0
   web: ^1.1.1
   collection: ^1.19.1
   http: ^1.5.0


### PR DESCRIPTION
## Summary

- validate `flutter_readium` with AGP 9.3, Gradle 9.5, and built-in Kotlin enabled
- use the conventional Kotlin source layout so both built-in and legacy Kotlin discover the plugin sources
- require `wakelock_plus` 1.7.0, whose Android implementation supports built-in Kotlin

## Verification

- `flutter build apk --debug` — passed with Flutter 3.47.2, AGP 9.3, and built-in Kotlin
- `bin/format` — passed
- `bin/analyze` — passed
- `:flutter_readium:compileDebugKotlin --offline` — passed in a disposable Flutter 3.44.8 / AGP 8.13 compatibility copy

A full APK build in the legacy compatibility copy reached dependency resolution but Maven DNS was unavailable for `androidx.test:runner:1.2+`; the targeted Kotlin compilation passed afterward from the local cache.

Fixes #204
