### PR TITLE
fix(Android): don't block UI using ReadiumReaderWidget

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **Creating `ReadiumReaderWidget` could freeze the Android UI while the native reader
+  initialized.** Publication positions, which Readium's EPUB fragment constructor reads with a
+  blocking call, are now fetched and cached on the I/O dispatcher first.
+
 ## [0.4.2] - 2026-08-28
 
 ### Fixed

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReader.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReader.kt
@@ -54,6 +54,7 @@ import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.LocatorCollection
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.html.cssSelector
+import org.readium.r2.shared.publication.services.positionsByReadingOrder
 import org.readium.r2.shared.publication.services.content.DefaultContentService
 import org.readium.r2.shared.publication.services.content.content
 import org.readium.r2.shared.publication.services.content.contentServiceFactory
@@ -952,6 +953,14 @@ object ReadiumReader :
         // Seed the runtime sync flag from the initial preference. If the preference
         // already disables synchronization, start in manual mode.
         narrationSyncEnabled = initialPreferences.disableSynchronization != true
+
+        // EpubNavigatorFragment 3.3.0 reads this position list with runBlocking from its
+        // constructor. For a streamed Web Publication that can be a network request, which would
+        // otherwise park Android's main thread for seconds or minutes. Populate the service cache
+        // first on the I/O dispatcher so the constructor's lookup is immediate.
+        withIOContext {
+            pub.positionsByReadingOrder()
+        }
 
         withMainContext {
             epubNavigator?.let {


### PR DESCRIPTION
# Description

`ReadiumReaderWidget` were blocking Flutter UI (buttons can't be pressed, animations stop, etc.), which was especially noticable when streaming a publication. 

## Before -> After


https://github.com/user-attachments/assets/00f7f6e4-9918-46b3-85cc-58dce2e2ba5e 

https://github.com/user-attachments/assets/10b5a779-e9cd-4ccd-b668-96e14aab3fe9

