### PR TITLE
fix: make sure loading widget hides when ReadiumReaderWidget is done

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **`ReadiumReaderWidget` could leave its loading widget visible after the publication had
+  rendered.** Native readers now send a dedicated per-widget visual-ready event instead of making
+  the loading state depend on a later, asynchronously enriched page-location event. The loading
+  widget also no longer intercepts pointer input while it is visible.
+
 ## [0.4.2] - 2026-08-28
 
 ### Fixed

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReaderChannel.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReaderChannel.kt
@@ -15,6 +15,8 @@ internal class ReadiumReaderChannel(
     name: String,
 ) : MethodChannel(messenger, name),
     CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate) {
+    fun onReaderReady() = launch { invokeMethod("onReaderReady", null) }
+
     fun onPageChanged(locator: Locator?) =
         launch {
             invokeMethod(

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReaderWidget.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/ReadiumReaderWidget.kt
@@ -274,6 +274,8 @@ class ReadiumReaderWidget(
 
     override fun onVisualReaderIsReady() {
         PluginLog.i(TAG, "::onVisualReaderIsReady")
+        channel.onReaderReady()
+
         if (!hasSentReady) {
             ReadiumReader.emitReaderStatusUpdate(ReadiumReaderStatus.Ready)
 

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/EPUBReaderView.swift
@@ -360,6 +360,7 @@ public class EPUBReaderView: NSObject, FlutterPlatformView, ReadiumReaderView, E
   public func navigator(_ navigator: Navigator, locationDidChange locator: Locator) {
     Log.reader.debug("onPageChanged: \(locator)")
     if (!hasSentReady) {
+      channel.onReaderReady()
       emitReaderStatusChanged(status: ReadiumReaderStatusReady)
       hasSentReady = true
     }

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/PDFReaderView.swift
@@ -124,6 +124,7 @@ public class PDFReaderView: NSObject, FlutterPlatformView, ReadiumReaderView, PD
   public func navigator(_ navigator: Navigator, locationDidChange locator: Locator) {
     Log.reader.debug("locationDidChange: \(locator)")
     if (!hasSentReady) {
+      channel.onReaderReady()
       emitReaderStatusChanged(status: ReadiumReaderStatusReady)
       hasSentReady = true
     }

--- a/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/ReadiumReaderChannel.swift
+++ b/flutter_readium/ios/flutter_readium/Sources/flutter_readium/reader/ReadiumReaderChannel.swift
@@ -9,6 +9,10 @@ class ReadiumReaderChannel: FlutterMethodChannel {
       taskQueue: nil)
   }
 
+  func onReaderReady() {
+    invokeMethod("onReaderReady", arguments: nil)
+  }
+
   func onPageChanged(locator: Locator) {
     invokeMethod("onPageChanged", arguments: try? locator.jsonString())
   }

--- a/flutter_readium/lib/reader_channel.dart
+++ b/flutter_readium/lib/reader_channel.dart
@@ -18,11 +18,13 @@ enum _ReaderChannelMethodInvoke {
 /// Internal use only.
 /// Used by ReadiumReaderWidget to talk to the native widget.
 class ReadiumReaderChannel extends MethodChannel {
-  /// Creates a channel bound to [name]. [onPageChanged] is called when the
-  /// native navigator reports a page change. [onExternalLinkActivated] is
+  /// Creates a channel bound to [name]. [onReaderReady] is called as soon as
+  /// the native navigator is visually ready. [onPageChanged] is called when
+  /// the native navigator reports a page change. [onExternalLinkActivated] is
   /// called when an external (non-publication) link is tapped.
   ReadiumReaderChannel(
     super.name, {
+    required this.onReaderReady,
     required this.onPageChanged,
     this.onExternalLinkActivated,
     this.onTextSelected,
@@ -34,6 +36,9 @@ class ReadiumReaderChannel extends MethodChannel {
   }
 
   static final _log = ReadiumLog.tag('ReaderChannel');
+
+  /// Called when the native reader has rendered its initial content.
+  final void Function() onReaderReady;
 
   /// Called by the native side whenever the visible page changes.
   final void Function(Locator) onPageChanged;
@@ -134,6 +139,11 @@ class ReadiumReaderChannel extends MethodChannel {
   Future<dynamic> onMethodCall(final MethodCall call) async {
     try {
       switch (call.method) {
+        case 'onReaderReady':
+          _log.d('onReaderReady');
+          onReaderReady();
+
+          return null;
         case 'onPageChanged':
           final args = call.arguments as String;
           final locatorJson = json.decode(args) as Map<String, dynamic>;

--- a/flutter_readium/lib/reader_widget.dart
+++ b/flutter_readium/lib/reader_widget.dart
@@ -40,7 +40,8 @@ class ReadiumReaderWidget extends StatefulWidget {
   final Publication publication;
 
   /// Optional widget to show while the reader is loading, e.g. a spinner.
-  /// It will be shown until the reader sends its first onPageChanged event.
+  /// It will be shown until the native reader reports that its initial content
+  /// is visually ready.
   /// It should typically be a full-screen widget, since it will be stacked on top of the reader widget.
   final Widget? loadingWidget;
 
@@ -243,7 +244,10 @@ class _ReadiumReaderWidgetState extends State<ReadiumReaderWidget> implements Re
             child: _readerWidget,
           ),
         ),
-        if (!isReady && widget.loadingWidget != null) Positioned.fill(child: widget.loadingWidget!),
+        if (!isReady && widget.loadingWidget != null)
+          Positioned.fill(
+            child: IgnorePointer(child: widget.loadingWidget!),
+          ),
       ],
     );
   }
@@ -386,14 +390,13 @@ class _ReadiumReaderWidgetState extends State<ReadiumReaderWidget> implements Re
   void _onPlatformViewCreated(final int id) {
     _channel = ReadiumReaderChannel(
       '$_viewType:$id',
+      onReaderReady: _markReady,
       onPageChanged: (final locator) {
         _log.d(() => 'onPageChanged: ${locator.toJson()}');
         _currentLocator = locator;
 
-        if (isReady == false) {
-          setState(() {
-            isReady = true;
-          });
+        _markReady();
+        if (!_isReadyCompleter.isCompleted) {
           _isReadyCompleter.complete(locator);
         }
       },
@@ -408,6 +411,16 @@ class _ReadiumReaderWidgetState extends State<ReadiumReaderWidget> implements Re
     }
 
     _log.d('New widget is: ${_channel?.name}');
+  }
+
+  void _markReady() {
+    if (!mounted || isReady) {
+      return;
+    }
+
+    setState(() {
+      isReady = true;
+    });
   }
 
   /// TODO: Remove this workaround, if the underlying issue is completely fixed in Readium.


### PR DESCRIPTION
# Description

Any loading widget passed to `ReadiumReaderWidget` stayed above the content after loading completed, often just less than a second, but in rare cases it stayed indefinitely. 

The solution in this PR is to listen on the initial content being visually ready (with the new `onReaderReady`), instead of `onPageChanged`. 

## Before -> After

https://github.com/user-attachments/assets/6b1dc5e9-68d2-4857-88d6-39ba7d65892f

https://github.com/user-attachments/assets/a98e87cc-a322-46a3-8467-5b016e0a88ed
