### PR TITLE
fix(android): serialize EPUB navigation after initial page load

### DIFF
--- a/flutter_readium/CHANGELOG.md
+++ b/flutter_readium/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **Android EPUB navigation could report the initial position after an immediate jump.**
+  Navigation now waits for the first page to load before applying a locator, so an initial
+  restore cannot race an explicit jump.
+
 ## [0.5.0] - 2026-09-11
 
 ### Added

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/fragments/EpubReaderFragment.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/fragments/EpubReaderFragment.kt
@@ -78,6 +78,9 @@ class EpubReaderFragment :
 
     val started = MutableStateFlow(false)
 
+    /** True after the current child navigator has loaded its first visible page. */
+    val pageLoaded = MutableStateFlow(false)
+
     val scrollMode: Boolean
         get() = epubNavigator?.settings?.value?.scroll == true
 
@@ -119,6 +122,7 @@ class EpubReaderFragment :
 
     override fun onPageLoaded() {
         PluginLog.d(TAG, "::onPageLoaded")
+        pageLoaded.value = true
         lifecycleScope.launch {
             applyCustomCssVariables()
             injectImageTapListeners()
@@ -578,6 +582,7 @@ class EpubReaderFragment :
 
             epubNavigator = null
             started.value = false
+            pageLoaded.value = false
 
             attachingNavigatorFragment = false
 

--- a/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/navigators/EpubNavigator.kt
+++ b/flutter_readium/android/src/main/kotlin/dk/nota/flutterreadium/navigators/EpubNavigator.kt
@@ -133,9 +133,6 @@ class EpubNavigator :
     /**
      * Checks when the fragment starts and is safe to use.
      */
-    private val navigatorStarted
-        get() = epubNavigator!!.started
-
     override suspend fun initNavigator() {
         epubNavigator =
             EpubReaderFragment().apply {
@@ -182,7 +179,7 @@ class EpubNavigator :
         PluginLog.d(TAG, "::go $locator animated:$animated")
 
         return withMainContext {
-            afterFragmentStarted()
+            afterFragmentStarted(navigator)
             segmentDuration?.takeIf { it > 0 }?.let {
                 navigator.evaluateJavascript("window.flutterReadium.setSegmentDuration(${it * 1000.0})")
             }
@@ -377,7 +374,7 @@ class EpubNavigator :
             return null
         }
 
-        afterFragmentStarted()
+        afterFragmentStarted(navigator)
         return withMainContext {
             navigator.evaluateJavascript(script)
         }
@@ -415,10 +412,12 @@ class EpubNavigator :
         }
     }
 
-    private suspend fun afterFragmentStarted() {
-        if (navigatorStarted.value) return
+    private suspend fun afterFragmentStarted(navigator: EpubReaderFragment) {
+        if (!navigator.started.value) {
+            navigator.started.first { it }
+        }
 
-        navigatorStarted.first { it }
+        navigator.pageLoaded.first { it }
     }
 
     suspend fun firstVisibleElementLocator(): Locator? {

--- a/flutter_readium/example/integration_test/groups/navigation_locator_test.dart
+++ b/flutter_readium/example/integration_test/groups/navigation_locator_test.dart
@@ -11,6 +11,48 @@ void main() {
   final harness = suiteHarness();
 
   group('Navigation and locator round-tripping', () {
+    testWidgets(
+      'Android EPUB immediate goToLocator settles on the requested resource',
+      (tester) async {
+        final path = harness.fixturePath(
+          FixtureKeys.reflowableEpub,
+          reason: 'Fixture ${FixtureKeys.reflowableEpub} missing from asset bundle',
+        );
+        final pub = await harness.readium.openPublication(path);
+        expect(pub.readingOrder.length, greaterThan(1));
+
+        final initialLocator = pub.locatorFromLink(pub.readingOrder.first)!;
+        final targetLocator = pub.locatorFromLink(pub.readingOrder[1])!;
+        final locators = <Locator>[];
+        final locatorSub = harness.readium.onTextLocatorChanged.listen(locators.add);
+        addTearDown(locatorSub.cancel);
+
+        await tester.pumpWidget(bareReaderApp(pub, initialLocator: initialLocator));
+        await tester.pump();
+
+        final navigated = await harness.readium.goToLocator(targetLocator);
+        expect(navigated, isTrue, reason: 'goToLocator should report success');
+
+        await waitWithPump(
+          tester,
+          () => locators.isNotEmpty && locators.last.href == targetLocator.href,
+          timeout: firstMountTimeout,
+          reason: 'Immediate goToLocator did not settle on the requested resource',
+          diagnostics: () => 'locators=$locators',
+        );
+        await waitForListStable(tester, locators);
+
+        expect(
+          locators.last.href,
+          equals(targetLocator.href),
+          reason: 'The initial restore must not overwrite the explicit jump',
+        );
+
+        await tester.pumpWidget(const SizedBox());
+      },
+      skip: !isAndroid(),
+    );
+
     testWidgets('EPUB goForward emits a new textLocator', (tester) async {
       final path = harness.fixturePath(
         FixtureKeys.reflowableEpub,


### PR DESCRIPTION
Calling `goToLocator` immediately after mounting an Android EPUB navigator could return success and then be overwritten by the navigator's initial restore, leaving the reader on the first reading-order item. Navigation now waits for the first visible page to load before applying the requested locator.

The regression test reproduces the race by navigating to the second reading-order item immediately after mounting the reader and waiting for the emitted locator to settle there.

Validation:

- Baseline regression test timed out after 60 seconds and remained on the first item.
- All 10 Android navigation integration tests passed with the fix.
- Kotlin compilation and plugin unit tests passed.
- `ktlint --format`, `bin/format`, `bin/analyze`, and `git diff --check` passed.
- The aggregate Gradle unit-test task remains red because the unrelated `wakelock_plus` test task cannot start its JUnit Platform executor; `:flutter_readium:testDebugUnitTest` passes.
